### PR TITLE
Remove BOM marks.

### DIFF
--- a/OpenRA.Mods.HV/Graphics/EnergyBoltRenderable.cs
+++ b/OpenRA.Mods.HV/Graphics/EnergyBoltRenderable.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2019-2020 The OpenHV Developers (see CREDITS)
  * This file is part of OpenHV, which is free software. It is made

--- a/OpenRA.Mods.HV/Projectiles/EnergyBolt.cs
+++ b/OpenRA.Mods.HV/Projectiles/EnergyBolt.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2019-2020 The OpenHV Developers (see CREDITS)
  * This file is part of OpenHV, which is free software. It is made

--- a/OpenRA.Mods.HV/Traits/Activities/EnterTeleportNetwork.cs
+++ b/OpenRA.Mods.HV/Traits/Activities/EnterTeleportNetwork.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2019-2020 The OpenHV Developers (see CREDITS)
  * This file is part of OpenHV, which is free software. It is made

--- a/OpenRA.Mods.HV/Traits/DebugOffsetOverlay.cs
+++ b/OpenRA.Mods.HV/Traits/DebugOffsetOverlay.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2019-2020 The OpenHV Developers (see CREDITS)
  * This file is part of OpenHV, which is free software. It is made

--- a/OpenRA.Mods.HV/Traits/Player/TeleportNetworkManager.cs
+++ b/OpenRA.Mods.HV/Traits/Player/TeleportNetworkManager.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2019-2020 The OpenHV Developers (see CREDITS)
  * This file is part of OpenHV, which is free software. It is made

--- a/OpenRA.Mods.HV/Traits/TeleportNetwork.cs
+++ b/OpenRA.Mods.HV/Traits/TeleportNetwork.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2019-2020 The OpenHV Developers (see CREDITS)
  * This file is part of OpenHV, which is free software. It is made

--- a/OpenRA.Mods.HV/Traits/TeleportNetworkPrimaryExit.cs
+++ b/OpenRA.Mods.HV/Traits/TeleportNetworkPrimaryExit.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2019-2020 The OpenHV Developers (see CREDITS)
  * This file is part of OpenHV, which is free software. It is made

--- a/OpenRA.Mods.HV/Traits/TeleportNetworkTransportable.cs
+++ b/OpenRA.Mods.HV/Traits/TeleportNetworkTransportable.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2019-2020 The OpenHV Developers (see CREDITS)
  * This file is part of OpenHV, which is free software. It is made

--- a/OpenRA.Mods.HV/Traits/World/DebugOffsetOverlayManager.cs
+++ b/OpenRA.Mods.HV/Traits/World/DebugOffsetOverlayManager.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2019-2020 The OpenHV Developers (see CREDITS)
  * This file is part of OpenHV, which is free software. It is made


### PR DESCRIPTION
This normalizes all C# source files to lack a BOM.