### PR TITLE
Offset shadows in pixels instead of world units.

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -48,7 +48,6 @@ BASE:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -1000,-150,0
 	RallyPoint:
 	Exit@0:
 		RequiresCondition: !being-captured
@@ -137,7 +136,6 @@ GENERATOR:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -1500,550,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -193,7 +191,6 @@ RADAR:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -300,350,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -248,7 +245,6 @@ TRADPLAT:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -250,50,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -326,7 +322,6 @@ MODULE:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -950,350,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -367,12 +362,10 @@ MINER2:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -2850,750,0
 		RequiresCondition: !build-incomplete
 	WithConstructionOverlay:
 		Sequence: make-shadow-overlay
 		Palette: shadow
-		Offset: -2850,750,0
 	RenderSprites:
 		PlayerPalette: green
 	GrantConditionOnDamageState@CRITICAL:
@@ -449,7 +442,6 @@ STARPORT:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -400,250,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -495,7 +487,6 @@ FACTORY2:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -850,300,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -541,7 +532,6 @@ FACTORY3:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -1350,350,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -587,7 +577,6 @@ TECHCENTER:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -500,300,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -657,7 +646,6 @@ TURRET:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -900,250,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -732,7 +720,6 @@ AATURRET:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -800,300,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -798,7 +785,6 @@ FIELD:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -250,100,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -918,7 +904,6 @@ STORAGE:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -300,150,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -984,7 +969,6 @@ ARTILLERYTURRET:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -1900,100,0
 		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
@@ -1049,7 +1033,6 @@ TELEVATR:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -250,150,0
 
 TELEVTR2:
 	Inherits: TELEVATR
@@ -1065,7 +1048,6 @@ TELEVTR2:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -250,150,0
 
 HARBOR:
 	Inherits: ^BaseBuilding
@@ -1128,7 +1110,6 @@ HARBOR:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		Offset: -200,200,0
 		RequiresCondition: !build-incomplete && !beam-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -859,7 +859,7 @@ SILO:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		RequiresCondition: !build-incomplete && !beam-incomplete
+		RequiresCondition: !build-incomplete
 
 STORAGE:
 	Inherits: ^BaseBuilding
@@ -1110,7 +1110,7 @@ HARBOR:
 		Sequence: shadow-overlay
 		Palette: shadow
 		IsDecoration: true
-		RequiresCondition: !build-incomplete && !beam-incomplete
+		RequiresCondition: !build-incomplete
 	WithMakeAnimation:
 		Condition: build-incomplete
 	WithConstructionBeamOverlay:
@@ -1120,10 +1120,10 @@ HARBOR:
 		RequiresCondition: !build-incomplete && !beam-incomplete
 	WithIdleOverlay@Entry:
 		Sequence: idle-entry
-		RequiresCondition: !build-incomplete && !beam-incomplete
+		RequiresCondition: !build-incomplete
 	WithIdleOverlay@Production:
 		Sequence: production
-		RequiresCondition: !build-incomplete && !beam-incomplete
+		RequiresCondition: !build-incomplete
 
 MOTHER:
 	Inherits: ^BaseBuilding

--- a/mods/hv/sequences/buildings.yaml
+++ b/mods/hv/sequences/buildings.yaml
@@ -36,6 +36,7 @@ base:
 		Tick: 300
 	shadow-overlay: base-shadow.png
 		ZOffset: 1768
+		Offset: -3, 13
 	damaged-idle: base.png
 		Start: 7
 		Length: 1
@@ -66,12 +67,14 @@ generator:
 		Tick: 300
 	shadow-overlay: generator-shadow.png
 		ZOffset: 1768
+		Offset: 12, 19
 	damaged-idle: generator.png
 		Start: 15
 		Length: 1
 	damaged-shadow-overlay: generator-shadow.png
 		Start: 1
 		ZOffset: 1768
+		Offset: 12, 19
 	make: build.png
 		Length: 39
 		Tick: 30
@@ -92,11 +95,13 @@ radar:
 	idle: radar.png
 	shadow-overlay: radar-shadow.png
 		ZOffset: 1768
+		Offset: 7, 4
 	damaged-idle: radar.png
 		Start: 1
 	damaged-shadow-overlay: radar-shadow.png
 		Start: 1
 		ZOffset: 1768
+		Offset: 7, 4
 	make: build.png
 		Length: 39
 		Tick: 30
@@ -110,20 +115,21 @@ radar:
 
 tradplat:
 	Inherits@flame: ^BuildingFlame2
+	Defaults:
+		Offset: 0, 1
 	idle: tradplat.png
-		Offset: 0,1
 		ZOffset: -1c511
 	shadow-overlay: tradplat-shadow.png
+		Offset: 1, 3
 	damaged-idle: tradplat.png
 		Start: 4
-		Offset: 0,1
 		ZOffset: -1c511
 	damaged-shadow-overlay: tradplat-shadow.png
 		Start: 1
+		Offset: 1, 3
 	active: tradplat.png
 		Frames: 1, 2, 3, 2, 1
 		Length: 5
-		Offset: 0,1
 		ZOffset: -1c511
 		Tick: 100
 	make: build.png
@@ -140,6 +146,7 @@ tradplat:
 		Offset: 12, -17
 	icon: buildings-icons.png
 		Start: 11
+		Offset: 0, 0
 
 module:
 	Inherits@flame: ^BuildingFlame2
@@ -152,11 +159,13 @@ module:
 	shadow-overlay: module-shadow.png
 		Start: 0
 		ZOffset: 1768
+		Offset: 7, 12
 	damaged-idle: module.png
 		Start: 9
 	damaged-shadow-overlay: module-shadow.png
 		Start: 1
 		ZOffset: 1768
+		Offset: 7, 12
 	make: build.png
 		Length: 39
 		Tick: 30
@@ -182,6 +191,7 @@ miner2:
 	make-shadow-overlay: miner2-shadow.png
 		Length: 17
 		Tick: 100
+		Offset: 15, 36
 	active: miner2.png
 		Start: 17
 		Length: 3
@@ -190,10 +200,12 @@ miner2:
 		Start: 17
 		Length: 3
 		Tick: 300
+		Offset: 15, 36
 	damaged-active: miner2.png
 		Start: 20
 	damaged-shadow-overlay: miner2-shadow.png
 		Start: 20
+		Offset: 15, 36
 	silo: miner2.png
 		Start: 21
 		Length: 6
@@ -212,11 +224,13 @@ starport:
 		Tick: 200
 	shadow-overlay: starport-shadow.png
 		ZOffset: 1768
+		Offset: 5, 5
 	damaged-idle: starport.png
 		Start: 22
 	damaged-shadow-overlay: starport-shadow.png
 		Start: 1
 		ZOffset: 1768
+		Offset: 5, 5
 	active: starport2.png
 		Length: 5
 	damaged-active: starport2.png
@@ -243,12 +257,14 @@ factory2:
 		Tick: 300
 	shadow-overlay: factory2-shadow.png
 		ZOffset: 1768
+		Offset: 6, 11
 	damaged-idle: factory2.png
 		Start: 15
 		Length: 1
 	damaged-shadow-overlay: factory2-shadow.png
 		Start: 1
 		ZOffset: 1768
+		Offset: 6, 11
 	make: build.png
 		Length: 39
 		Tick: 30
@@ -271,12 +287,14 @@ factory3:
 		Tick: 300
 	shadow-overlay: factory3-shadow.png
 		ZOffset: 1768
+		Offset: 7, 17
 	damaged-idle: factory3.png
 		Start: 11
 		Length: 1
 	damaged-shadow-overlay: factory3-shadow.png
 		Start: 1
 		ZOffset: 1768
+		Offset: 7, 17
 	make: build.png
 		Length: 39
 		Tick: 30
@@ -298,6 +316,7 @@ turret:
 		Start: 0
 	shadow-overlay: turret-shadow.png
 		ZOffset: 1768
+		Offset: 5, 11
 	damaged-idle: turret.png
 		Start: 1
 	turret: turret.png
@@ -325,6 +344,7 @@ aaturret:
 		Start: 0
 	shadow-overlay: aa-turret-shadow.png
 		ZOffset: 1768
+		Offset: 6, 10
 	damaged-idle: aa-turret.png
 		Start: 1
 	turret: aa-turret.png
@@ -354,6 +374,7 @@ field:
 	idle: field.png
 	shadow-overlay: field-shadow.png
 		ZOffset: 1768
+		Offset: 2, 3
 	active: field.png
 		Length: 5
 		Tick: 300
@@ -387,6 +408,7 @@ silo:
 		Start: 1
 	shadow-overlay: silo-shadow.png
 		ZOffset: 1768
+		Offset: 3, 5
 	make: build.png
 		Length: 39
 		Tick: 30
@@ -407,6 +429,7 @@ storage:
 	idle: storage.png
 	shadow-overlay: storage-shadow.png
 		ZOffset: 1768
+		Offset: 3, 4
 	stages: storage.png
 		Length: 14
 	damaged-stages: storage.png
@@ -430,6 +453,7 @@ artilleryturret:
 		Start: 0
 	shadow-overlay: artilery2-shadow.png
 		ZOffset: 1768
+		Offset: 2, 24
 	damaged-idle: artilery2.png
 		Start: 1
 	turret: artilery2.png
@@ -460,6 +484,7 @@ televatr:
 		Start: 15
 	shadow-overlay: televatr-shadow.png
 		ZOffset: 1768
+		Offset: 3, 3
 	damaged-idle: televatr.png
 		Start: 16
 	active: televatr.png
@@ -484,6 +509,7 @@ televtr2:
 		Start: 7
 	shadow-overlay: televtr2-shadow.png
 		ZOffset: 1768
+		Offset: 3, 3
 	damaged-idle: televtr2.png
 		Start: 14
 	active: televtr2.png
@@ -509,6 +535,7 @@ harbor:
 		ZOffset: -2000
 	shadow-overlay: harbor-shadow.png
 		ZOffset: -1768
+		Offset: 4, 4
 	production: harbor.png
 		Start: 3
 		Length: 7
@@ -578,8 +605,10 @@ techcenter:
 		Start: 0
 	shadow-overlay: tech-center-shadow.png
 		ZOffset: 1768
+		Offset: 6, 6
 	damaged-shadow-overlay: tech-center-shadow-damaged.png
 		ZOffset: 1768
+		Offset: 6, 6
 	damaged-idle: tech-center.png
 		Start: 1
 	animation: tech-center.png


### PR DESCRIPTION
World units might lead to rounding errors on different zoom levels and weren't aligned with the artwork anyway.

Dependency of #140.