### PR TITLE
Remove UseClassicPerspectiveFudge from BodyOrientation.

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -1033,8 +1033,7 @@ TELEVTR2:
 	Inherits@shape: ^1x2Shape
 	HitShape:
 		UseTargetableCellsOffsets: false
-		# TODO: Figure out why these can't be 512. - Graion; 2020-08-09. 
-		TargetableOffsets: 0,0,0, -832,0,0, 832,0,0
+		TargetableOffsets: 0,0,0, -512,0,0, 512,0,0
 	-Buildable:
 	-PlaceBuildingVariants:
 	Selectable:

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -10,6 +10,7 @@
 
 ^SpriteActor:
 	BodyOrientation:
+		UseClassicPerspectiveFudge: false
 	QuantizeFacingsFromSequence:
 	RenderSprites:
 


### PR DESCRIPTION
https://github.com/OpenRA/OpenRA/blob/56739f87fb0ecf6df08e3e24367ddca4a896fd5e/OpenRA.Mods.Common/Traits/BodyOrientation.cs#L26 doesn't apply to us because we're using an actual topdown perspective (this is coming from RA1).

This breaks weapon firing offsets though which I haven't fixed yet.