### PR TITLE
Remove the tooltip from Mount Brosnan's lavalight.

### DIFF
--- a/mods/hv/maps/mount-brosnan/rules.yaml
+++ b/mods/hv/maps/mount-brosnan/rules.yaml
@@ -4,8 +4,6 @@
 
 LAVALIGHT:
 	Inherits: LIGHT
-	Tooltip:
-		Name: Red Lighting
 	TerrainLightSource:
 		Range: 15c640
 		Intensity: 0.01


### PR DESCRIPTION
This fixes the custom rules warning in the map selection.