### PR TITLE
Further capture polishes.

### DIFF
--- a/OpenRA.Mods.HV/Traits/BotModules/PriorityCaptureManagerBotModule.cs
+++ b/OpenRA.Mods.HV/Traits/BotModules/PriorityCaptureManagerBotModule.cs
@@ -62,8 +62,6 @@ namespace OpenRA.Mods.HV.Traits
 		readonly Player player;
 		readonly int maximumCaptureTargetOptions;
 
-		readonly List<Actor> activeCapturers = new List<Actor>();
-
 		int minCaptureDelayTicks;
 		IPathFinder pathfinder;
 		DomainIndex domainIndex;
@@ -176,8 +174,6 @@ namespace OpenRA.Mods.HV.Traits
 							bot.QueueOrder(new Order("CaptureActor", capturer.Actor, safeTarget, true));
 							AIUtils.BotDebug("AI ({0}): Ordered {1} {2} to capture {3} {4} in priority mode.",
 								player.ClientIndex, capturer.Actor, capturer.Actor.ActorID, priorityTarget, priorityTarget.ActorID);
-
-							activeCapturers.Add(capturer.Actor);
 						}
 
 						priorityTargets = priorityTargets.Skip(1);
@@ -225,7 +221,6 @@ namespace OpenRA.Mods.HV.Traits
 
 					bot.QueueOrder(new Order("CaptureActor", capturer.Actor, safeTarget, true));
 					AIUtils.BotDebug("AI ({0}): Ordered {1} to capture {2}", player.ClientIndex, capturer.Actor, nearestTargetActor);
-					activeCapturers.Add(capturer.Actor);
 				}
 			}
 		}

--- a/OpenRA.Mods.HV/Traits/BotModules/PriorityCaptureManagerBotModule.cs
+++ b/OpenRA.Mods.HV/Traits/BotModules/PriorityCaptureManagerBotModule.cs
@@ -221,6 +221,7 @@ namespace OpenRA.Mods.HV.Traits
 
 					bot.QueueOrder(new Order("CaptureActor", capturer.Actor, safeTarget, true));
 					AIUtils.BotDebug("AI ({0}): Ordered {1} to capture {2}", player.ClientIndex, capturer.Actor, nearestTargetActor);
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
The second commit was added because queueing up to 15 targets stressed the pathfinder and led to lag spikes.