### PR TITLE
Updated tick rate for some buildings' idle animations.

### DIFF
--- a/mods/hv/sequences/buildings.yaml
+++ b/mods/hv/sequences/buildings.yaml
@@ -35,7 +35,7 @@ base:
 	idle: bits/base.png
 		Length: 3
 		Reverses: true
-		Tick: 300
+		Tick: 150
 	shadow-overlay: bits/base-shadow.png
 		ZOffset: 1768
 		Offset: 7, -17
@@ -99,7 +99,7 @@ generator:
 		Offset: 0, -8
 	idle: bits/generator.png
 		Length: 15
-		Tick: 300
+		Tick: 80
 	shadow-overlay: bits/generator-shadow.png
 		ZOffset: 1768
 		Offset: 12, 11
@@ -290,7 +290,7 @@ starport:
 	idle: bits/starport.png
 		Frames: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
 		Length: *
-		Tick: 200
+		Tick: 100
 	shadow-overlay: bits/starport-shadow.png
 		ZOffset: 1768
 		Offset: 5, 3
@@ -323,7 +323,7 @@ starport2:
 	idle: bits/starport2.png
 		Frames: 0, 1, 2, 3, 4, 3, 2, 1
 		Length: *
-		Tick: 200
+		Tick: 100
 	shadow-overlay: bits/starport-shadow.png
 		ZOffset: 1768
 		Offset: 5, 3
@@ -356,7 +356,7 @@ factory2:
 	idle: bits/null.png
 	idle-online: bits/factory2.png
 		Length: 15
-		Tick: 300
+		Tick: 100
 	idle-offline: bits/factory2.png
 	shadow-overlay: bits/factory2-shadow.png
 		ZOffset: 1768
@@ -428,7 +428,7 @@ factory3:
 	idle: bits/null.png
 	idle-online: bits/factory3.png
 		Length: 11
-		Tick: 300
+		Tick: 100
 	idle-offline: bits/factory3.png
 	shadow-overlay: bits/factory3-shadow.png
 		ZOffset: 1768


### PR DESCRIPTION
Well, a lot of animations felt way too slow. It should be better now, however factories are still wonky. I guess it is due to their animations which need be split up for idle one and the one when an actor is created (just like the Base does it). Starports could have similar treatment.