### PR TITLE
Turn the carryall to a shared unit.

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -184,7 +184,8 @@ COPTER2:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 50
-		Prerequisites: radar, ~aircraft.sc
+		# YI needs a counterpart transport plane.
+		Prerequisites: radar
 		Description: Fast Vehicle Transport Helicopter.\n  Unarmed
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true


### PR DESCRIPTION
This is to fix the balance issue on Tomb Raiders.