### PR TITLE
vscode debugging: build before launching

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             "program": "${workspaceRoot}/engine/OpenRA.Game.exe",
-            "cwd": "${workspaceRoot}",
+            "cwd": "${workspaceRoot}/engine/",
             "args": [
                 "Engine.LaunchPath=${workspaceRoot}",
                 "Engine.ModSearchPaths=${workspaceRoot}/mods",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,12 @@
             "request": "launch",
             "program": "${workspaceRoot}/engine/OpenRA.Game.exe",
             "cwd": "${workspaceRoot}",
-            "args": ["Engine.LaunchPath=${workspaceRoot}", "Engine.ModSearchPaths=${workspaceRoot}/mods", "Game.Mod=hv", "Debug.DisplayDeveloperSettings=true"]
+            "args": [
+                "Engine.LaunchPath=${workspaceRoot}",
+                "Engine.ModSearchPaths=${workspaceRoot}/mods",
+                "Game.Mod=hv",
+                "Debug.DisplayDeveloperSettings=true",
+            ]
         },
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
                 "type": "mono"
             },
             "request": "launch",
+            "preLaunchTask": "build",
             "program": "${workspaceRoot}/engine/OpenRA.Game.exe",
             "cwd": "${workspaceRoot}",
             "args": [


### PR DESCRIPTION
Like https://github.com/OpenRA/OpenRA/pull/18786 but for OpenHV.
Also fix the configured [cwd] to be the engine dir, so that SDL (and other build artifacts) can be found.
This is equivalent to the `cd "${ENGINE_DIRECTORY}"` in `launch-game.sh`.

[cwd]: https://en.wikipedia.org/wiki/Current_working_directory