### PR TITLE
Balance changes

### DIFF
--- a/mods/hv/mod.yaml
+++ b/mods/hv/mod.yaml
@@ -42,6 +42,7 @@ Rules:
 	hv|rules/bonus.yaml
 	hv|rules/weapons.yaml
 	hv|rules/bots.yaml
+	hv|rules/pods.yaml
 
 Sequences:
 	hv|sequences/animals.yaml

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -1,5 +1,54 @@
 # License: CC-BY-SA-4.0
 
+SHIP2:
+	Inherits: ^Plane
+	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Buildable:
+		Queue: Aircraft
+		BuildPaletteOrder: 30
+		Prerequisites: radar, ~aircraft.yi
+		Description: Attack Ship armed with\na large chain gun.
+	Valued:
+		Cost: 1000
+	Tooltip:
+		Name: Gun Ship
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 10000
+	RevealsShroud:
+		Range: 11c0
+		Type: GroundPosition
+	Armament@PRIMARY:
+		Weapon: ChainGun.Shuttle
+		LocalOffset: 256,0,0
+		MuzzleSequence: muzzle
+	AttackAircraft:
+		FacingTolerance: 20
+		PersistentTargeting: false
+		OpportunityFire: false
+	Aircraft:
+		CruiseAltitude: 2560
+		InitialFacing: 768
+		TurnSpeed: 16
+		Speed: 180
+		RepulsionSpeed: 40
+		MaximumPitch: 56
+	AutoTarget:
+		InitialStance: HoldFire
+		InitialStanceAI: HoldFire
+	WithMuzzleOverlay:
+	Contrail:
+		Offset: -400,0,0
+		UsePlayerColor: false
+		Color: A0000060
+		TrailWidth: 0c96
+		TrailLength: 5
+	Selectable:
+		Bounds: 1024, 1024
+	RenderSprites:
+		PlayerPalette: green
+
 SHIP1:
 	Inherits: ^Plane
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
@@ -9,7 +58,7 @@ SHIP1:
 		Prerequisites: radar, ~aircraft.yi
 		Description: Fast Attack Ship
 	Valued:
-		Cost: 2000
+		Cost: 1500
 	Tooltip:
 		Name: Speeder
 	UpdatesPlayerStatistics:
@@ -31,7 +80,7 @@ SHIP1:
 		CruiseAltitude: 2560
 		InitialFacing: 768
 		TurnSpeed: 16
-		Speed: 223
+		Speed: 180
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	AutoTarget:
@@ -48,61 +97,12 @@ SHIP1:
 	RenderSprites:
 		PlayerPalette: green
 
-SHIP2:
-	Inherits: ^Plane
-	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Buildable:
-		Queue: Aircraft
-		BuildPaletteOrder: 30
-		Prerequisites: radar, ~aircraft.yi
-		Description: Attack Ship armed with\na large chain gun.
-	Valued:
-		Cost: 1350
-	Tooltip:
-		Name: Gun Ship
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 6000
-	RevealsShroud:
-		Range: 11c0
-		Type: GroundPosition
-	Armament@PRIMARY:
-		Weapon: ChainGun.Shuttle
-		LocalOffset: 256,0,0
-		MuzzleSequence: muzzle
-	AttackAircraft:
-		FacingTolerance: 20
-		PersistentTargeting: false
-		OpportunityFire: false
-	Aircraft:
-		CruiseAltitude: 2560
-		InitialFacing: 768
-		TurnSpeed: 16
-		Speed: 178
-		RepulsionSpeed: 40
-		MaximumPitch: 56
-	AutoTarget:
-		InitialStance: HoldFire
-		InitialStanceAI: HoldFire
-	WithMuzzleOverlay:
-	Contrail:
-		Offset: -400,0,0
-		UsePlayerColor: false
-		Color: A0000060
-		TrailWidth: 0c96
-		TrailLength: 5
-	Selectable:
-		Bounds: 1024, 1024
-	RenderSprites:
-		PlayerPalette: green
-
 COPTER:
 	Inherits: ^Helicopter
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Inherits@MAGAZINECASING: ^DropShellCasing
 	Valued:
-		Cost: 1500
+		Cost: 1000
 	Tooltip:
 		Name: Attack Helicopter
 	Buildable:
@@ -115,11 +115,11 @@ COPTER:
 	Health:
 		HP: 10000
 	RevealsShroud:
-		Range: 10c0
+		Range: 8c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 16
-		Speed: 112
+		TurnSpeed: 20
+		Speed: 115
 	Turreted:
 		TurnSpeed: 80
 		Offset: 200,0,-100
@@ -140,7 +140,7 @@ COPTER:
 SAUCER:
 	Inherits: ^Helicopter
 	Valued:
-		Cost: 1500
+		Cost: 400
 	Tooltip:
 		Name: Scout Saucer
 	Buildable:
@@ -151,13 +151,13 @@ SAUCER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 10000
+		HP: 8000
 	RevealsShroud:
-		Range: 10c0
+		Range: 15c0
 		Type: GroundPosition
 	Aircraft:
 		TurnSpeed: 16
-		Speed: 112
+		Speed: 70
 	-WithShadow:
 	Selectable:
 		Bounds: 1228, 1228
@@ -220,7 +220,7 @@ COPTER2:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 14000
+		HP: 15000
 	RevealsShroud:
 		Range: 8c0
 		Type: GroundPosition
@@ -245,7 +245,7 @@ COPTER2:
 		LocalOffset: 0,0,-100
 	Cargo:
 		Types: Scout
-		MaxWeight: 4
+		MaxWeight: 5
 		AfterUnloadDelay: 40
 	Carryall:
 		BeforeLoadDelay: 10
@@ -260,7 +260,7 @@ COPTER2:
 BALLOON:
 	Inherits: ^Helicopter
 	Valued:
-		Cost: 500
+		Cost: 400
 	Tooltip:
 		Name: Scout Balloon
 	Buildable:
@@ -276,7 +276,7 @@ BALLOON:
 		Range: 18c0
 		Type: GroundPosition
 	Aircraft:
-		Speed: 60
+		Speed: 70
 	Selectable:
 		DecorationBounds: 1228, 1638
 	-WithShadow:
@@ -318,7 +318,7 @@ DROPSHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 14000
+		HP: 15000
 	RevealsShroud:
 		Range: 8c0
 		Type: GroundPosition

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -765,7 +765,7 @@ TURRET:
 	Targetable:
 		TargetTypes: Ground, Structure
 	Health:
-		HP: 30000
+		HP: 50000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -835,7 +835,7 @@ TURRET2:
 	Targetable:
 		TargetTypes: Ground, Structure
 	Health:
-		HP: 30000
+		HP: 50000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -904,7 +904,7 @@ AATURRET:
 		Prerequisites: factory2, ~structures.yi
 		Description: Anti-Air base defense.\nRequires power to operate.
 	Valued:
-		Cost: 1000
+		Cost: 1250
 	Tooltip:
 		Name: AA Turret
 	Building:
@@ -914,7 +914,7 @@ AATURRET:
 	Targetable:
 		TargetTypes: Ground, Structure
 	Health:
-		HP: 30000
+		HP: 45000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -985,7 +985,7 @@ AATURRET2:
 		Prerequisites: factory2, ~structures.sc
 		Description: Anti-Air base defense.\nRequires power to operate.
 	Valued:
-		Cost: 1000
+		Cost: 1250
 	Tooltip:
 		Name: AA Turret
 	Building:
@@ -995,7 +995,7 @@ AATURRET2:
 	Targetable:
 		TargetTypes: Ground, Structure
 	Health:
-		HP: 30000
+		HP: 45000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -1309,7 +1309,7 @@ ARTILLERYTURRET:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 90
-		Prerequisites: factory3
+		Prerequisites: factory3, techcenter
 		Description: Advanced base defense.\nRequires power to operate.
 	Valued:
 		Cost: 2000
@@ -1321,7 +1321,7 @@ ARTILLERYTURRET:
 	Targetable:
 		TargetTypes: Ground, Structure
 	Health:
-		HP: 45000
+		HP: 60000
 	Armor:
 		Type: Steel
 	RevealsShroud:

--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -1,0 +1,139 @@
+# License: CC-BY-SA-4.0
+
+SCOUT1:
+	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Buildable:
+		Queue: Scouts
+		Description: Fast reconnaissance vehicle.\nArmed with machine guns.
+		Prerequisites: module
+	Valued:
+		Cost: 100
+	Tooltip:
+		Name: Machine Gun Pod
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 15000
+	Armor:
+		Type: None
+	Mobile:
+		TurnSpeed: 100
+		Speed: 120
+		Locomotor: pod
+	RevealsShroud:
+		Range: 8c0
+	Armament:
+		Weapon: LightMachineGun
+		MuzzleSequence: muzzle
+	AttackFrontal:
+		PauseOnCondition: ecmdisabled
+		Voice: Attack
+	WithMuzzleOverlay:
+	RenderSprites:
+		PlayerPalette: green
+	Passenger:
+		CargoType: Scout
+	-Carryable:
+	-SpawnScrapOnDeath:
+	-Explodes:
+	WithDeathAnimation:
+		UseDeathTypeSuffix: false
+		DeathSequencePalette: effect
+		FallbackSequence: die
+		DeathPaletteIsPlayerPalette: false
+		Delay: 5
+
+SCOUT2:
+	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
+	Buildable:
+		Queue: Scouts
+		Description: Fast reconnaissance vehicle.\nShoots rockets.
+		Prerequisites: module
+	Valued:
+		Cost: 250
+	Tooltip:
+		Name: Rocket Pod
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 15000
+	Armor:
+		Type: None
+	Mobile:
+		TurnSpeed: 100
+		Speed: 120
+		Locomotor: pod
+	RevealsShroud:
+		Range: 8c0
+	Armament@PRIMARY:
+		Weapon: LightAntiTankRocket
+		MuzzleSequence: muzzle
+		LocalOffset: 50,0,0
+	Armament@SECONDARY:
+		Weapon: LightAntiAirRocket
+		MuzzleSequence: muzzle
+		LocalOffset: 50,0,0
+	AttackFrontal:
+		PauseOnCondition: ecmdisabled
+		Voice: Attack
+	WithMuzzleOverlay:
+	RenderSprites:
+		PlayerPalette: green
+	Passenger:
+		CargoType: Scout
+	-Carryable:
+	-SpawnScrapOnDeath:
+	-Explodes:
+	WithDeathAnimation:
+		UseDeathTypeSuffix: false
+		DeathSequencePalette: effect
+		FallbackSequence: die
+		DeathPaletteIsPlayerPalette: false
+		Delay: 5
+
+TECHNICIAN:
+	Inherits: ^Vehicle
+	Inherits@SELECTION: ^SelectableSupportUnit
+	Buildable:
+		Queue: Scouts
+		Description: Armored technician.\nInfiltrates and captures enemy structures.\n  Unarmed
+		Prerequisites: module
+	Valued:
+		Cost: 500
+	Tooltip:
+		Name: Combat technician
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	CaptureManager:
+	Captures:
+		CaptureTypes: building
+		PlayerExperience: 25
+		CaptureDelay: 375
+		ConsumedByCapture: false
+		EnterCursor: ability
+		EnterBlockedCursor: move-blocked
+	Health:
+		HP: 12500
+	Armor:
+		Type: None
+	Mobile:
+		TurnSpeed: 100
+		Speed: 80
+		Locomotor: pod
+	RenderSprites:
+		PlayerPalette: green
+	RevealsShroud:
+		Range: 6c0
+	Passenger:
+		CargoType: Scout
+	-Carryable:
+	-SpawnScrapOnDeath:
+	-Explodes:
+	WithDeathAnimation:
+		UseDeathTypeSuffix: false
+		DeathSequencePalette: effect
+		FallbackSequence: die
+		DeathPaletteIsPlayerPalette: false
+		Delay: 5

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -1,10 +1,48 @@
 # License: CC-BY-SA-4.0
 
+BOAT3:
+	Inherits: ^Ship
+	Inherits@AUTOTARGET: ^AutoTargetAir
+	Valued:
+		Cost: 500
+	Tooltip:
+		Name: Light Boat
+		GenericName: Boat
+	Buildable:
+		Queue: Ship
+		BuildAtProductionType: Ship
+		Prerequisites: harbor
+		BuildPaletteOrder: 40
+		Description: Anti-Air light boat.
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 25000
+	Armor:
+		Type: Light
+	Mobile:
+		Speed: 150
+		TurnSpeed: 60
+	RevealsShroud:
+		Range: 5c0
+	Turreted:
+		TurnSpeed: 120
+		Offset: -50,0,100
+	Armament:
+		Weapon: BoatMissile_AA
+		LocalOffset: 0,0,0
+	AttackTurreted:
+	WithSpriteTurret:
+	WithTurretAttackAnimation:
+		Sequence: shoot
+	RenderSprites:
+		PlayerPalette: green
+
 BOAT:
 	Inherits: ^Ship
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 700
+		Cost: 800
 	Tooltip:
 		Name: Medium Boat
 		GenericName: Boat
@@ -17,7 +55,7 @@ BOAT:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 33000
+		HP: 46000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -29,9 +67,9 @@ BOAT:
 		TurnSpeed: 60
 		Offset: 150,0,100
 	Armament:
-		Weapon: TyrianTankCannon
-		Recoil: 75
-		RecoilRecovery: 25
+		Weapon: ^Cannon
+		Recoil: 125
+		RecoilRecovery: 38
 		MuzzleSequence: muzzle
 		LocalOffset: 200,0,-50
 	AttackTurreted:
@@ -51,17 +89,17 @@ BOAT2:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: harbor
+		Prerequisites: harbor, techcenter
 		BuildPaletteOrder: 40
 		Description: A heavy boat with a railgun.
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 55000
+		HP: 60000
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 80
+		Speed: 75
 		TurnSpeed: 40
 	RevealsShroud:
 		Range: 5c0
@@ -74,44 +112,6 @@ BOAT2:
 		LocalOffset: 500,0,0 # TODO: to be adjusted
 	AttackTurreted:
 	WithSpriteTurret:
-	RenderSprites:
-		PlayerPalette: green
-
-BOAT3:
-	Inherits: ^Ship
-	Inherits@AUTOTARGET: ^AutoTargetAir
-	Valued:
-		Cost: 700
-	Tooltip:
-		Name: Light Boat
-		GenericName: Boat
-	Buildable:
-		Queue: Ship
-		BuildAtProductionType: Ship
-		Prerequisites: harbor
-		BuildPaletteOrder: 40
-		Description: Anti-Air light boat.
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 33000
-	Armor:
-		Type: Heavy
-	Mobile:
-		Speed: 150
-		TurnSpeed: 60
-	RevealsShroud:
-		Range: 5c0
-	Turreted:
-		TurnSpeed: 120
-		Offset: -50,0,100
-	Armament:
-		Weapon: BoatMissile_AA
-		LocalOffset: 0,0,0
-	AttackTurreted:
-	WithSpriteTurret:
-	WithTurretAttackAnimation:
-		Sequence: shoot
 	RenderSprites:
 		PlayerPalette: green
 

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -1,102 +1,36 @@
 # License: CC-BY-SA-4.0
 
-TANK1:
-	Inherits: ^Vehicle
-	Valued:
-		Cost: 400
-	Tooltip:
-		Name: Ramp Buggy
-		GenericName: Buggy
-	Buildable:
-		BuildPaletteOrder: 20
-		Prerequisites: ~vehicles.sc, factory2
-		Queue: Vehicle
-		Description: Remote controlled vehicle\narmed with explosives.
-		BuildAtProductionType: Wheeled
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 9000
-	Armor:
-		Type: Light
-	Mobile:
-		Speed: 170
-	RevealsShroud:
-		Range: 7c0
-	Demolition:
-		DetonationDelay: 45
-		EnterBehaviour: Dispose
-		Cursor: ability
-	Passenger:
-		CustomPipType: red
-		Voice: Move
-	RenderSprites:
-		PlayerPalette: green
-
-TANK2:
-	Inherits: ^TrackedVehicle
-	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Valued:
-		Cost: 400
-	Tooltip:
-		Name: Laser Bike
-		GenericName: Bike
-	Buildable:
-		Queue: Vehicle
-		Prerequisites: ~disabled
-		BuildPaletteOrder: 20
-		Description: Fires lasers.
-		BuildAtProductionType: Wheeled
-	AttackFrontal:
-		PauseOnCondition: ecmdisabled
-		Voice: Attack
-	Armament:
-		Weapon: RedLaser
-		LocalOffset: 500,-250,0
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 12000
-	Armor:
-		Type: Light
-	Mobile:
-		Speed: 500
-	RevealsShroud:
-		Range: 7c0
-	RenderSprites:
-		PlayerPalette: green
-
 TANK3:
 	Inherits: ^TrackedVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 650
+		Cost: 800
 	Tooltip:
 		Name: Assault Tank
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
-		BuildPaletteOrder: 120
+		BuildPaletteOrder: 10
 		Prerequisites: factory2, ~vehicles.sc
 		Queue: Vehicle
-		Description: Fast, light tank.
+		Description: Main Battle Tank.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 		BuildAtProductionType: Wheeled
 	Mobile:
-		TurnSpeed: 20
-		Speed: 110
+		TurnSpeed: 25
+		Speed: 100
 	Health:
-		HP: 34000
+		HP: 46000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		TurnSpeed: 20
+		TurnSpeed: 25
 		Offset: -125,0,50
 	Armament:
-		Weapon: 30mm
-		Recoil: 75
-		RecoilRecovery: 25
+		Weapon: ^Cannon
+		Recoil: 125
+		RecoilRecovery: 38
 		MuzzleSequence: muzzle
 		LocalOffset: 500,-50,-50
 	AttackTurreted:
@@ -107,18 +41,173 @@ TANK3:
 	RenderSprites:
 		PlayerPalette: green
 
+TYRIANTANK:
+	Inherits: ^TrackedVehicle
+	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Valued:
+		Cost: 800
+	Tooltip:
+		Name: Assault Tank
+		GenericName: Tank
+	Buildable:
+		Queue: Vehicle
+		Prerequisites: factory2, ~vehicles.yi
+		BuildPaletteOrder: 10
+		Description: Main Battle Tank.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
+		BuildAtProductionType: Wheeled
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 46000
+	Armor:
+		Type: Heavy
+	Mobile:
+		TurnSpeed: 25
+		Speed: 100
+	RevealsShroud:
+		Range: 5c0
+	Turreted:
+		TurnSpeed: 25
+	Armament:
+		Weapon: ^Cannon
+		Recoil: 125
+		RecoilRecovery: 38
+		MuzzleSequence: muzzle
+		LocalOffset: 550,-50,0
+	AttackTurreted:
+		PauseOnCondition: ecmdisabled
+		Voice: Attack
+	WithSpriteTurret:
+	WithMuzzleOverlay:
+	RenderSprites:
+		PlayerPalette: green
+
+TANK9:
+	Inherits: ^TrackedVehicle
+	Inherits@AUTOTARGET: ^AutoTargetAir
+	Buildable:
+		Queue: Vehicle
+		BuildPaletteOrder: 20
+		Prerequisites: factory2
+		Description: Mobile tank with AA missiles.
+		BuildAtProductionType: Tracked
+	Valued:
+		Cost: 500
+	Tooltip:
+		Name: Mobile AA
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 15000
+	Armor:
+		Type: Light
+	Mobile:
+		TurnSpeed: 40
+		Speed: 115
+	RevealsShroud:
+		Range: 6c0
+	Turreted:
+		TurnSpeed: 40
+	Armament:
+		Weapon: Patriot
+		LocalOffset: 543,0,815
+	AttackTurreted:
+		PauseOnCondition: ecmdisabled
+		Voice: Attack
+
+TRANSPRT:
+	Inherits: ^TrackedVehicle
+	Valued:
+		Cost: 600
+	Tooltip:
+		Name: Transport Tank
+	Buildable:
+		Queue: Vehicle
+		Prerequisites: module
+		BuildPaletteOrder: 30
+		Description: Can transport smaller vehicles.
+		BuildAtProductionType: Tracked
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 25000
+	Armor:
+		Type: Heavy
+	Mobile:
+		Speed: 125
+		PauseOnCondition: notmobile || ecmdisabled
+	RevealsShroud:
+		Range: 5c0
+	Cargo:
+		Types: Scout
+		MaxWeight: 5
+		LoadingCondition: notmobile
+	Selectable:
+		DecorationBounds: 2048, 1843
+	RenderSprites:
+		PlayerPalette: green
+	WithCargoPipsDecoration:
+		Position: BottomLeft
+		RequiresSelection: true
+	WithTeleportEnergyOverlay:
+		Image: energyball
+		Sequence: teleport-large
+
+ARTIL:
+	Inherits: ^TrackedVehicle
+	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Valued:
+		Cost: 850
+	Tooltip:
+		Name: Artillery
+	Buildable:
+		Queue: Vehicle
+		Prerequisites: radar, factory2
+		BuildPaletteOrder: 40
+		Description: Mobile long range weapon.
+		BuildAtProductionType: Tracked
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 15000
+	Armor:
+		Type: Light
+	Mobile:
+		TurnSpeed: 15
+		Speed: 85
+		Locomotor: lighttracked
+	RevealsShroud:
+		Range: 5c0
+	Armament:
+		Weapon: SmallArtillery
+		MuzzleSequence: muzzle
+		LocalOffset: 500,0,100
+	AttackFrontal:
+		Armaments: primary
+		TargetFrozenActors: true
+		ForceFireIgnoresActors: true
+		PauseOnCondition: ecmdisabled
+		Voice: Attack
+	WithMuzzleOverlay:
+	Explodes:
+		Weapon: ArtilleryExplode
+		EmptyWeapon: UnitExplodeSmall
+		LoadedChance: 75
+	RenderSprites:
+		PlayerPalette: green
+
 TANK4:
 	Inherits: ^TrackedVehicle
 	Inherits@SELECTION: ^SelectableSupportUnit
 	-AppearsOnRadar:
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 90
+		BuildPaletteOrder: 50
 		Prerequisites: radar
 		Description: Can detect cloaked units.n\nRange extends when deployed.\n  Unarmed
 		BuildAtProductionType: Wheeled
 	Valued:
-		Cost: 950
+		Cost: 400
 	Tooltip:
 		Name: Reconnaissance Tank
 		RequiresCondition: !deployed
@@ -126,7 +215,7 @@ TANK4:
 		Name: Reconnaissance Tank (deployed)
 		RequiresCondition: deployed
 	Health:
-		HP: 60000
+		HP: 50000
 	Armor:
 		Type: Light
 	Mobile:
@@ -166,37 +255,44 @@ TANK4:
 	RenderDetectionCircle:
 		TrailCount: 3
 
-TANK5:
+TANK16:
 	Inherits: ^TrackedVehicle
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 700
+		Cost: 800
 	Tooltip:
-		Name: Rocket Tank
+		Name: Mobile Repair Vehicle
 		GenericName: Tank
 	Buildable:
 		Queue: Vehicle
-		Prerequisites: factory2, ~vehicles.sc
-		BuildPaletteOrder: 110
-		Description: Shoots rockets.
+		Prerequisites: factory2, tradplat
+		BuildPaletteOrder: 60
+		Description: Repairs nearby vehicles.
 		BuildAtProductionType: Wheeled
-	Armament@PRIMARY:
-		Weapon: AntiAirRocket
-	Armament@SECONDARY:
-		Weapon: AntiGroundRocket
+	Armament:
+		Weapon: Repair
+		Cursor: repair
+		OutsideRangeCursor: repair
+		TargetRelationships: Ally
+		ForceTargetRelationships: None
 	AttackFrontal:
 		PauseOnCondition: ecmdisabled
-		Voice: Attack
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 22000
+		HP: 20000
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 118
+		Speed: 85
+		TurnSpeed: 20
 	RevealsShroud:
 		Range: 5c0
+	AutoTarget:
+		ScanRadius: 8
+		InitialStance: AttackAnything
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Vehicle
 	RenderSprites:
 		PlayerPalette: green
 
@@ -205,12 +301,12 @@ TANK6:
 	Inherits@SELECTION: ^SelectableSupportUnit
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 170
+		BuildPaletteOrder: 70
 		Prerequisites: factory2, tradplat
 		Description: Lays mines to destroy\nunwary enemy units.\nCan detect mines.\n  Unarmed
 		BuildAtProductionType: Wheeled
 	Valued:
-		Cost: 800
+		Cost: 700
 	Tooltip:
 		Name: Minelayer
 	UpdatesPlayerStatistics:
@@ -241,23 +337,89 @@ TANK6:
 	RenderSprites:
 		PlayerPalette: green
 
+TANK5:
+	Inherits: ^TrackedVehicle
+	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
+	Valued:
+		Cost: 1500
+	Tooltip:
+		Name: Railgun Tank
+		GenericName: Tank
+	Buildable:
+		Queue: Vehicle
+		Prerequisites: factory2, techcenter, ~vehicles.sc
+		BuildPaletteOrder: 150
+		Description: A powerful tank which shoots laser.
+		BuildAtProductionType: Wheeled
+	Armament:
+		Weapon: railgun
+		LocalOffset: 325,350,0
+	AttackFrontal:
+		PauseOnCondition: ecmdisabled
+		Voice: Attack
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 50000
+	Armor:
+		Type: Heavy
+	Mobile:
+		Speed: 75
+	RevealsShroud:
+		Range: 6c0
+	RenderSprites:
+		PlayerPalette: green
+
+TANK10:
+	Inherits: ^TrackedVehicle
+	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Buildable:
+		Queue: Vehicle
+		BuildPaletteOrder: 150
+		Prerequisites: factory3, techcenter, ~vehicles.yi
+		Description: Fires electric discharges.
+		BuildAtProductionType: Tracked
+	Valued:
+		Cost: 1500
+	Tooltip:
+		Name: Lightning Tank
+		GenericName: Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 50000
+	Armor:
+		Type: Heavy
+	Mobile:
+		Speed: 75
+	RevealsShroud:
+		Range: 6c0
+	Armament:
+		Weapon: VoltageArc
+		LocalOffset: 0,0,213
+	AttackFrontal:
+		PauseOnCondition: ecmdisabled
+		Voice: Attack
+	RenderSprites:
+		PlayerPalette: green
+
 TANK7:
 	Inherits: ^TrackedVehicle
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 270
+		BuildPaletteOrder: 120
 		Prerequisites: factory3, techcenter
 		Description: Cloaked missile tank.\nCan ambush enemies.
 		BuildAtProductionType: Tracked
 	Valued:
-		Cost: 600
+		Cost: 900
 	Tooltip:
 		Name: Stealth Tank
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 20000
+		HP: 30000
 	Armor:
 		Type: Heavy
 	AttackFrontal:
@@ -267,9 +429,9 @@ TANK7:
 		Weapon: StealthTankMissile
 		LocalOffset: 213,43,128, 213,-43,128
 	Mobile:
-		Speed: 160
+		Speed: 120
 	RevealsShroud:
-		Range: 8c0
+		Range: 6c0
 	Cloak:
 		InitialDelay: 90
 		CloakDelay: 90
@@ -278,106 +440,6 @@ TANK7:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
-	RenderSprites:
-		PlayerPalette: green
-
-TANK8:
-	Inherits: ^TrackedVehicle
-	Inherits@SELECTION: ^SelectableSupportUnit
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 160
-		Prerequisites: factory2, ~vehicles.yi
-		Description: Rogue SysOp in a tank.\nInfiltrates and captures enemy structures.\n  Unarmed
-		BuildAtProductionType: Wheeled
-	Valued:
-		Cost: 400
-	Tooltip:
-		Name: Hacker Tank
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	CaptureManager:
-	Captures:
-		CaptureTypes: building
-		PlayerExperience: 25
-		CaptureDelay: 375
-		ConsumedByCapture: false
-		EnterCursor: ability
-		EnterBlockedCursor: move-blocked
-	Health:
-		HP: 10000
-	Armor:
-		Type: Heavy
-	Mobile:
-		Speed: 150
-	RenderSprites:
-		PlayerPalette: green
-	RevealsShroud:
-		Range: 6c0
-
-TANK9:
-	Inherits: ^TrackedVehicle
-	Inherits@AUTOTARGET: ^AutoTargetAir
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 130
-		Prerequisites: aircraft
-		Description: Mobile tank with AA missiles.
-		BuildAtProductionType: Tracked
-	Valued:
-		Cost: 600
-	Tooltip:
-		Name: Mobile AA
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 15000
-	Armor:
-		Type: Light
-	Mobile:
-		TurnSpeed: 40
-		Speed: 118
-	RevealsShroud:
-		Range: 6c0
-	Turreted:
-		TurnSpeed: 40
-	Armament:
-		Weapon: Patriot
-		LocalOffset: 543,0,815
-	AttackTurreted:
-		PauseOnCondition: ecmdisabled
-		Voice: Attack
-
-TANK10:
-	Inherits: ^TrackedVehicle
-	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 330
-		Prerequisites: factory3, techcenter
-		Description: Fires electric discharges.
-		BuildAtProductionType: Tracked
-	Valued:
-		Cost: 1350
-	Tooltip:
-		Name: Lightning Tank
-		GenericName: Tank
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 40000
-	Armor:
-		Type: Light
-	Mobile:
-		Speed: 99
-	RevealsShroud:
-		Range: 7c0
-	Armament:
-		Weapon: VoltageArc
-		LocalOffset: 0,0,213
-	AttackFrontal:
-		PauseOnCondition: ecmdisabled
-		Voice: Attack
 	RenderSprites:
 		PlayerPalette: green
 
@@ -391,12 +453,12 @@ TANK11:
 		GenericName: Tank
 	Buildable:
 		Queue: Vehicle
-		Prerequisites: factory3, ~vehicles.sc
-		BuildPaletteOrder: 220
+		Prerequisites: ~disabled #factory3, ~vehicles.sc
+		BuildPaletteOrder: 180
 		Description: Main battle tank.
 		BuildAtProductionType: Tracked
 	Armament:
-		Weapon: 90mm
+		Weapon: ^Cannon
 	AttackFrontal:
 		PauseOnCondition: ecmdisabled
 		Voice: Attack
@@ -423,8 +485,8 @@ TANK12:
 		GenericName: Tank
 	Buildable:
 		Queue: Vehicle
-		Prerequisites: factory3, ~vehicles.yi
-		BuildPaletteOrder: 240
+		Prerequisites: ~disabled #factory3, ~vehicles.yi
+		BuildPaletteOrder: 190
 		Description: Double barreled tank.
 		BuildAtProductionType: Tracked
 	Armament:
@@ -483,14 +545,14 @@ TANK15:
 	Inherits: ^TrackedVehicle
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 1000
 	Tooltip:
 		Name: Countermeasure Tank
 		GenericName: ECM Tank
 	Buildable:
 		Queue: Vehicle
-		Prerequisites: techcenter
-		BuildPaletteOrder: 130
+		Prerequisites: techcenter, tradplat
+		BuildPaletteOrder: 110
 		Description: Disables units.
 		BuildAtProductionType: Tracked
 	Armament:
@@ -503,136 +565,14 @@ TANK15:
 	Health:
 		HP: 30000
 	Armor:
-		Type: Heavy
+		Type: Light
 	Mobile:
-		Speed: 118
+		Speed: 110
 	RevealsShroud:
 		Range: 6c0
 	JamsMissiles:
 		Range: 5c0
 		DeflectionRelationships: Neutral, Enemy
-	RenderSprites:
-		PlayerPalette: green
-
-TANK16:
-	Inherits: ^TrackedVehicle
-	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
-	Valued:
-		Cost: 800
-	Tooltip:
-		Name: Mobile Repair Vehicle
-		GenericName: Tank
-	Buildable:
-		Queue: Vehicle
-		Prerequisites: factory2, tradplat
-		BuildPaletteOrder: 170
-		Description: Repairs nearby vehicles.
-		BuildAtProductionType: Wheeled
-	Armament:
-		Weapon: Repair
-		Cursor: repair
-		OutsideRangeCursor: repair
-		TargetRelationships: Ally
-		ForceTargetRelationships: None
-	AttackFrontal:
-		PauseOnCondition: ecmdisabled
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 20000
-	Armor:
-		Type: Heavy
-	Mobile:
-		Speed: 85
-		TurnSpeed: 20
-	RevealsShroud:
-		Range: 5c0
-	AutoTarget:
-		ScanRadius: 8
-		InitialStance: AttackAnything
-	AutoTargetPriority@DEFAULT:
-		ValidTargets: Vehicle
-	RenderSprites:
-		PlayerPalette: green
-
-TRANSPRT:
-	Inherits: ^TrackedVehicle
-	Valued:
-		Cost: 850
-	Tooltip:
-		Name: Transport Tank
-	Buildable:
-		Queue: Vehicle
-		Prerequisites: factory3, module
-		BuildPaletteOrder: 140
-		Description: Can transport smaller vehicles.
-		BuildAtProductionType: Tracked
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 35000
-	Armor:
-		Type: Heavy
-	Mobile:
-		Speed: 142
-		PauseOnCondition: notmobile || ecmdisabled
-	RevealsShroud:
-		Range: 5c0
-	Cargo:
-		Types: Scout
-		MaxWeight: 4
-		LoadingCondition: notmobile
-	Selectable:
-		DecorationBounds: 2048, 1843
-	RenderSprites:
-		PlayerPalette: green
-	WithCargoPipsDecoration:
-		Position: BottomLeft
-		RequiresSelection: true
-	WithTeleportEnergyOverlay:
-		Image: energyball
-		Sequence: teleport-large
-
-ARTIL:
-	Inherits: ^TrackedVehicle
-	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Valued:
-		Cost: 850
-	Tooltip:
-		Name: Artillery
-	Buildable:
-		Queue: Vehicle
-		Prerequisites: radar, factory2, ~vehicles.sc
-		BuildPaletteOrder: 150
-		Description: Mobile long range weapon.
-		BuildAtProductionType: Tracked
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 10000
-	Armor:
-		Type: Light
-	Mobile:
-		TurnSpeed: 8
-		Speed: 85
-		Locomotor: lighttracked
-	RevealsShroud:
-		Range: 5c0
-	Armament:
-		Weapon: SmallArtillery
-		MuzzleSequence: muzzle
-		LocalOffset: 500,0,100
-	AttackFrontal:
-		Armaments: primary
-		TargetFrozenActors: true
-		ForceFireIgnoresActors: true
-		PauseOnCondition: ecmdisabled
-		Voice: Attack
-	WithMuzzleOverlay:
-	Explodes:
-		Weapon: ArtilleryExplode
-		EmptyWeapon: UnitExplodeSmall
-		LoadedChance: 75
 	RenderSprites:
 		PlayerPalette: green
 
@@ -657,7 +597,7 @@ ARTIL2:
 		Type: Light
 	Mobile:
 		TurnSpeed: 8
-		Speed: 85
+		Speed: 60
 		Locomotor: lighttracked
 	RevealsShroud:
 		Range: 5c0
@@ -684,15 +624,15 @@ ARTIL3:
 	Inherits: ^TrackedVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 950
+		Cost: 1750
 	Tooltip:
 		Name: Dual Artillery
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 200
-		Prerequisites: radar, factory3, ~vehicles.yi
+		BuildPaletteOrder: 140
+		Prerequisites: radar, factory3, techcenter, ~vehicles.yi
 		Description: Double barreled artillery tank.
 		BuildAtProductionType: Tracked
 	Health:
@@ -700,10 +640,10 @@ ARTIL3:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 71
-		TurnSpeed: 20
+		TurnSpeed: 8
+		Speed: 60
 	RevealsShroud:
-		Range: 9c0
+		Range: 8c0
 	Armament:
 		Weapon: DoubleBarrelledArtillery
 		MuzzleSequence: muzzle
@@ -721,142 +661,6 @@ ARTIL3:
 		DecorationBounds: 1536, 1536
 	RenderSprites:
 		PlayerPalette: green
-
-SCOUT1:
-	Inherits: ^Vehicle
-	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Buildable:
-		Queue: Scouts
-		BuildPaletteOrder: 130
-		Description: Fast reconnaissance vehicle.\nArmed with machine guns.
-		Prerequisites: module
-	Valued:
-		Cost: 500
-	Tooltip:
-		Name: Scout Pod
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 15000
-	Armor:
-		Type: Light
-	Mobile:
-		TurnSpeed: 40
-		Speed: 170
-		Locomotor: pod
-	RevealsShroud:
-		Range: 8c0
-	Armament:
-		Weapon: LightMachineGun
-		MuzzleSequence: muzzle
-	AttackFrontal:
-		PauseOnCondition: ecmdisabled
-		Voice: Attack
-	WithMuzzleOverlay:
-	RenderSprites:
-		PlayerPalette: green
-	Passenger:
-		CargoType: Scout
-	-Carryable:
-	-SpawnScrapOnDeath:
-	WithDeathAnimation:
-		UseDeathTypeSuffix: false
-		DeathSequencePalette: effect
-		FallbackSequence: die
-		DeathPaletteIsPlayerPalette: false
-		Delay: 5
-
-SCOUT2:
-	Inherits: ^Vehicle
-	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
-	Buildable:
-		Queue: Scouts
-		BuildPaletteOrder: 130
-		Description: Fast reconnaissance vehicle.\nShoots rockets.
-		Prerequisites: module
-	Valued:
-		Cost: 500
-	Tooltip:
-		Name: Rocket Pod
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 15000
-	Armor:
-		Type: Light
-	Mobile:
-		TurnSpeed: 40
-		Speed: 170
-		Locomotor: pod
-	RevealsShroud:
-		Range: 8c0
-	Armament@PRIMARY:
-		Weapon: LightAntiTankRocket
-		MuzzleSequence: muzzle
-		LocalOffset: 50,0,0
-	Armament@SECONDARY:
-		Weapon: LightAntiAirRocket
-		MuzzleSequence: muzzle
-		LocalOffset: 50,0,0
-	AttackFrontal:
-		PauseOnCondition: ecmdisabled
-		Voice: Attack
-	WithMuzzleOverlay:
-	RenderSprites:
-		PlayerPalette: green
-	Passenger:
-		CargoType: Scout
-	-Carryable:
-	-SpawnScrapOnDeath:
-	WithDeathAnimation:
-		UseDeathTypeSuffix: false
-		DeathSequencePalette: effect
-		FallbackSequence: die
-		DeathPaletteIsPlayerPalette: false
-		Delay: 5
-
-TECHNICIAN:
-	Inherits: ^Vehicle
-	Inherits@SELECTION: ^SelectableSupportUnit
-	Buildable:
-		Queue: Scouts
-		BuildPaletteOrder: 130
-		Description: Armored technician.\nInfiltrates and captures enemy structures.\n  Unarmed
-		Prerequisites: module, ~vehicles.sc
-	Valued:
-		Cost: 500
-	Tooltip:
-		Name: Combat technician
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	CaptureManager:
-	Captures:
-		CaptureTypes: building
-		PlayerExperience: 25
-		EnterCursor: ability
-		EnterBlockedCursor: move-blocked
-	Health:
-		HP: 10000
-	Armor:
-		Type: Light
-	Mobile:
-		TurnSpeed: 40
-		Speed: 150
-		Locomotor: pod
-	RenderSprites:
-		PlayerPalette: green
-	RevealsShroud:
-		Range: 6c0
-	Passenger:
-		CargoType: Scout
-	-Carryable:
-	-SpawnScrapOnDeath:
-	WithDeathAnimation:
-		UseDeathTypeSuffix: false
-		DeathSequencePalette: effect
-		FallbackSequence: die
-		DeathPaletteIsPlayerPalette: false
-		Delay: 5
 
 BUILDER:
 	Inherits: ^Vehicle
@@ -882,7 +686,7 @@ BUILDER:
 		Type: Light
 	Mobile:
 		TurnSpeed: 32
-		Speed: 120
+		Speed: 100
 	RevealsShroud:
 		Range: 6c0
 	RenderSprites:
@@ -891,46 +695,6 @@ BUILDER:
 	-WithFacingSpriteBody:
 	WithRandomFacingSpriteBody:
 		Images: builder1, builder2, builder3, builder4, builder5
-
-TYRIANTANK:
-	Inherits: ^TrackedVehicle
-	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Valued:
-		Cost: 700
-	Tooltip:
-		Name: Assault Tank
-		GenericName: Tank
-	Buildable:
-		Queue: Vehicle
-		Prerequisites: factory2, ~vehicles.yi
-		BuildPaletteOrder: 40
-		Description: Tank with rotating turret.
-		BuildAtProductionType: Wheeled
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 33000
-	Armor:
-		Type: Heavy
-	Mobile:
-		Speed: 100
-	RevealsShroud:
-		Range: 5c0
-	Turreted:
-		TurnSpeed: 20
-	Armament:
-		Weapon: TyrianTankCannon
-		Recoil: 50
-		RecoilRecovery: 25
-		MuzzleSequence: muzzle
-		LocalOffset: 550,-50,0
-	AttackTurreted:
-		PauseOnCondition: ecmdisabled
-		Voice: Attack
-	WithSpriteTurret:
-	WithMuzzleOverlay:
-	RenderSprites:
-		PlayerPalette: green
 
 MINER:
 	Inherits: ^Vehicle
@@ -951,7 +715,7 @@ MINER:
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 40
+		TurnSpeed: 30
 		Speed: 80
 	RevealsShroud:
 		Range: 8c0
@@ -972,40 +736,137 @@ MISSILE_TANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 700
+		Cost: 1200
 	Tooltip:
 		Name: Missile Tank
 		GenericName: Tank
 	Buildable:
 		Queue: Vehicle
-		Prerequisites: factory3, ~vehicles.yi
+		Prerequisites: radar, factory3, techcenter, ~vehicles.sc
 		BuildPaletteOrder: 240
 		Description: A tank which shoots missiles.
 		BuildAtProductionType: Tracked
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 33000
+		HP: 45000
 	Armor:
-		Type: Medium
+		Type: Heavy
 	Mobile:
-		Speed: 120
+		Speed: 80
 	RevealsShroud:
 		Range: 5c0
 	Turreted:
 		TurnSpeed: 40
 		Offset: -250,-50,100
-	Armament@PRIMARY:
+	Armament:
 		Weapon: MissileTankRocket
-		LocalOffset: 500,0,0 # TODO: to be adjusted
-	Armament@SECONDARY:
-		Weapon: MissileTankRocket_AA
-		LocalOffset: 0,0,0 # TODO: to be adjusted
+		LocalOffset: 500,0,0
 	AttackTurreted:
 		PauseOnCondition: ecmdisabled
 		Voice: Attack
 	WithSpriteTurret:
 	WithMuzzleOverlay:
+	RenderSprites:
+		PlayerPalette: green
+
+TANK8:
+	Inherits: ^TrackedVehicle
+	Inherits@SELECTION: ^SelectableSupportUnit
+	Buildable:
+		Queue: Vehicle
+		BuildPaletteOrder: 200
+		Prerequisites: ~disabled #factory2, ~vehicles.yi
+		Description: Rogue SysOp in a tank.\nInfiltrates and captures enemy structures.\n  Unarmed
+		BuildAtProductionType: Wheeled
+	Valued:
+		Cost: 400
+	Tooltip:
+		Name: Hacker Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	CaptureManager:
+	Captures:
+		CaptureTypes: building
+		PlayerExperience: 25
+		CaptureDelay: 375
+		ConsumedByCapture: false
+		EnterCursor: ability
+		EnterBlockedCursor: move-blocked
+	Health:
+		HP: 10000
+	Armor:
+		Type: Heavy
+	Mobile:
+		Speed: 150
+	RenderSprites:
+		PlayerPalette: green
+	RevealsShroud:
+		Range: 6c0
+
+TANK1:
+	Inherits: ^Vehicle
+	Valued:
+		Cost: 400
+	Tooltip:
+		Name: Ramp Buggy
+		GenericName: Buggy
+	Buildable:
+		BuildPaletteOrder: 200
+		Prerequisites: ~disabled #~vehicles.sc, factory2
+		Queue: Vehicle
+		Description: Remote controlled vehicle\narmed with explosives.
+		BuildAtProductionType: Wheeled
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 9000
+	Armor:
+		Type: Light
+	Mobile:
+		Speed: 140
+	RevealsShroud:
+		Range: 7c0
+	Demolition:
+		DetonationDelay: 45
+		EnterBehaviour: Dispose
+		Cursor: ability
+	Passenger:
+		CustomPipType: red
+		Voice: Move
+	RenderSprites:
+		PlayerPalette: green
+
+TANK2:
+	Inherits: ^TrackedVehicle
+	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Valued:
+		Cost: 400
+	Tooltip:
+		Name: Laser Bike
+		GenericName: Bike
+	Buildable:
+		Queue: Vehicle
+		Prerequisites: ~disabled
+		BuildPaletteOrder: 210
+		Description: Fires lasers.
+		BuildAtProductionType: Wheeled
+	AttackFrontal:
+		PauseOnCondition: ecmdisabled
+		Voice: Attack
+	Armament:
+		Weapon: RedLaser
+		LocalOffset: 500,-250,0
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 12000
+	Armor:
+		Type: Light
+	Mobile:
+		Speed: 500
+	RevealsShroud:
+		Range: 7c0
 	RenderSprites:
 		PlayerPalette: green
 

--- a/mods/hv/weapons/ballistics.yaml
+++ b/mods/hv/weapons/ballistics.yaml
@@ -3,8 +3,8 @@
 ^Cannon:
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
 	Report: tankfire01.wav
-	ReloadDelay: 50
-	Range: 4c768
+	ReloadDelay: 70
+	Range: 6c0
 	Projectile: Bullet
 		Speed: 682
 		Image: bullet1
@@ -17,9 +17,10 @@
 		Spread: 128
 		Damage: 4000
 		Versus:
-			None: 30
+			None: 75
 			Steel: 75
 			Light: 75
+			Heavy: 125
 			Wood: 75
 	Warhead@GroundEffect: CreateEffect
 		Explosions: small
@@ -44,21 +45,13 @@
 		InvalidTargets: Ship, Structure
 		ImpactSounds: Video_Game_Splash-Ploor.wav
 
-TyrianTankCannon:
-	Inherits: ^Cannon
-	Report: tankfire02.wav
-	ReloadDelay: 70
-	Warhead@Damage: SpreadDamage
-		Versus:
-			Heavy: 115
-
 ^Artillery:
 	Inherits: ^Cannon
 	Report: howitzerfire01.wav
 	ReloadDelay: 85
 	Range: 12c0
 	Projectile: Bullet
-		Speed: 170
+		Speed: 200
 		Blockable: false
 		LaunchAngle: 62
 		Inaccuracy: 1c938
@@ -70,7 +63,7 @@ TyrianTankCannon:
 		Damage: 23000
 		Versus:
 			None: 90
-			Steel: 40
+			Steel: 45
 			Light: 60
 			Heavy: 25
 			Wood: 40
@@ -91,7 +84,7 @@ SmallArtillery:
 
 DoubleBarrelledArtillery:
 	Inherits: ^Artillery
-	ReloadDelay: 150
+	ReloadDelay: 200
 	Range: 18c0
 	MinRange: 5c0
 	Burst: 2
@@ -102,12 +95,19 @@ DoubleBarrelledArtillery:
 		LaunchAngle: 165
 		Inaccuracy: 2c0
 	Warhead@Damage: SpreadDamage
-		Damage: 11000
+		Spread: 500
+		Damage: 23000
+		Versus:
+			None: 150
+			Steel: 60
+			Light: 60
+			Heavy: 50
+			Wood: 40
 
 TurretCannon:
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
 	Report: tankfire01.wav
-	ReloadDelay: 50
+	ReloadDelay: 25
 	Range: 8c0
 	Projectile: Bullet
 		Speed: 682
@@ -118,9 +118,10 @@ TurretCannon:
 		Spread: 128
 		Damage: 5000
 		Versus:
-			None: 30
+			None: 90
 			Steel: 75
 			Light: 75
+			Heavy: 85
 	Warhead@GroundEffect: CreateEffect
 		Explosions: small
 		ValidTargets: Ground
@@ -147,7 +148,7 @@ TurretCannon:
 Turret2Cannon:
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
 	Report: blaster-newlocknew.wav
-	ReloadDelay: 50
+	ReloadDelay: 25
 	Range: 8c0
 	Projectile: Bullet
 		Speed: 682
@@ -158,9 +159,10 @@ Turret2Cannon:
 		Spread: 128
 		Damage: 2500
 		Versus:
-			None: 30
+			None: 90
 			Steel: 75
 			Light: 75
+			Heavy: 85
 	Warhead@GroundEffect: CreateEffect
 		Explosions: small
 		ValidTargets: Ground
@@ -254,17 +256,24 @@ TurretArtillery:
 	Inherits: ^Artillery
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
 	Report: heavycannonfire01.wav
-	ReloadDelay: 200
+	ReloadDelay: 150
 	MinRange: 5c0
 	Range: 20c0
 	Projectile: Bullet
-		Speed: 204
+		Speed: 300
 		LaunchAngle: 100
 		Inaccuracy: 2c0
 		Image: bullet2
 		Shadow: true
 	Warhead@Damage: SpreadDamage
 		Damage: 30000
+		Spread: 750
+		Versus:
+			None: 60
+			Steel: 50
+			Light: 60
+			Heavy: 60
+			Wood: 40
 	Warhead@Effect: CreateEffect
 		Explosions: large
 		ImpactSounds: explosion07.wav, explosion08.wav
@@ -310,11 +319,6 @@ TurretArtillery:
 		ValidTargets: Swamp
 		InvalidTargets: Ship, Structure
 		ImpactSounds: Video_Game_Splash-Ploor.wav
-
-90mm:
-	Inherits: ^Cannon
-	Projectile: Bullet
-		Image: bullet5
 
 105mm:
 	Inherits: ^Cannon

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -2,14 +2,14 @@
 
 railgun:
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
-	Range: 9c0
+	Range: 8c0
 	ReloadDelay: 100
 	Report: ray_gun-Mike_Koenig.wav
 	Projectile: LaserZap
 		Width: 0c100
 		Shape: Cylindrical
 		ZOffset: 2000
-		Color: FE0303 #DE8200
+		Color: FE0303
 	Warhead@Smudge: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@Damage: SpreadDamage
@@ -18,9 +18,11 @@ railgun:
 		Spread: 128
 		Damage: 7500
 		Versus:
-			None: 30
+			None: 150
 			Steel: 75
-			Light: 75
+			Light: 100
+			Heavy: 155
+			Wood: 10
 	Warhead@GroundEffect: CreateEffect
 		Explosions: small
 		ValidTargets: Ground
@@ -98,22 +100,22 @@ ElectronicCountermeasureEffect:
 		Damage: 0
 
 Repair:
-	ReloadDelay: 80
-	Range: 1c819
+	ReloadDelay: 5
+	Range: 2c0
 	Projectile: LaserZap
 		ZOffset: 2047
-		Color: 0000FF80
+		Color: fffff2
 		SecondaryBeam: true
 		SecondaryBeamZOffset: 2047
 		Width: 36
-		Duration: 8
+		Duration: 2
 		SecondaryBeamWidth: 144
-		SecondaryBeamColor: 0000FF30
+		SecondaryBeamColor: f09000
 	ValidTargets: Repair
 	TargetActorCenter: true
 	Warhead@Repair: TargetDamage
 		DebugOverlayColor: 00FF00
-		Damage: -5000
+		Damage: -250
 		ValidTargets: Repair
 		Spread: 1
 
@@ -122,7 +124,7 @@ Plasma:
 	ReloadDelay: 50
 	Burst: 3
 	BurstDelays: 5
-	Range: 5c0
+	Range: 6c0
 	MinRange: 0c512
 	Report: laser_Cannon-Mike_Koenig.wav
 	Projectile: Bullet
@@ -141,8 +143,8 @@ Plasma:
 		Versus:
 			None: 10
 			Steel: 74
-			Light: 34
-			Heavy: 100
+			Light: 75
+			Heavy: 125
 			Concrete: 50
 	Warhead@Effect: CreateEffect
 		Explosions: small
@@ -168,22 +170,28 @@ Plasma:
 		ImpactSounds: Video_Game_Splash-Ploor.wav
 
 VoltageArc:
-	ReloadDelay: 120
-	Range: 7c0
+	ReloadDelay: 100
+	Range: 8c0
 	Report: railgunfire02.wav
 	Projectile: EnergyBolt
 		Radius: 2
-		Duration: 12
+		Duration: 5
 		InnerLightness: 192
 		OuterLightness: 96
-		Color: 4444CC
+		Color: 2668bd
 		Distortion: 200
-		DistortionAnimation: 120
+		DistortionAnimation: 150
 		SegmentLength: 0c512
 	ValidTargets: Ground, Water, Vehicle, Lava, Swamp
 	Warhead@Damage: SpreadDamage
-		Spread: 42
-		Damage: 10000
+		Spread: 128
+		Damage: 7500
+		Versus:
+			None: 150
+			Steel: 75
+			Light: 100
+			Heavy: 155
+			Wood: 10
 		ValidTargets: Ground, Water, Vehicle, Lava, Swamp
 		DamageTypes: Electricity
 	Warhead@Sparks: FireShrapnel

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -6,11 +6,11 @@ LightMachineGun:
 	Projectile: InstantHit
 		Inaccuracy: 0c256
 	Warhead@Damage: SpreadDamage
-		Spread: 128
-		Damage: 2500
+		Spread: 24
+		Damage: 1000
 		Versus:
 			None: 150
-			Steel: 10
+			Steel: 25
 			Light: 30
 			Heavy: 10
 			Concrete: 10
@@ -36,27 +36,27 @@ LightMachineGun:
 		ValidTargets: Swamp
 		InvalidTargets: Ship, Structure
 		ImpactSounds: Video_Game_Splash-Ploor.wav
-	ReloadDelay: 30
-	Range: 4c0
+	ReloadDelay: 20
+	Range: 5c0
 	Burst: 2
 
 ChainGun:
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
 	ReloadDelay: 10
-	Range: 5c0
+	Range: 6c0
 	Report: ccbysmgfire01.wav
 	Projectile: InstantHit
 		Blockable: false
 	MinRange: 0c768
 	Burst: 4
 	Warhead@1Dam: SpreadDamage
-		Spread: 128
-		Damage: 250
+		Spread: 64
+		Damage: 1000
 		Versus:
-			None: 144
+			None: 175
 			Steel: 60
-			Light: 72
-			Heavy: 28
+			Light: 75
+			Heavy: 25
 			Concrete: 28
 	Warhead@Effect: CreateEffect
 		Image: hit
@@ -89,13 +89,14 @@ ChainGun.Shuttle:
 	Projectile: InstantHit
 		Blockable: false
 	Warhead@Damage: SpreadDamage
-		Damage: 400
+		Spread: 64
+		Damage: 1000
 		Versus:
-			None: 100
-			Steel: 50
-			Light: 60
-			Heavy: 25
-			Concrete: 25
+			None: 200
+			Steel: 75
+			Light: 85
+			Heavy: 35
+			Concrete: 28
 
 ShellCasing:
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
@@ -140,10 +141,11 @@ Vulcan:
 	Projectile: InstantHit
 		Blockable: false
 	Warhead@Damage: SpreadDamage
-		Damage: 200
+		Spread: 64
+		Damage: 1000
 		Versus:
-			None: 120
-			Steel: 50
-			Light: 60
-			Heavy: 25
-			Concrete: 25
+			None: 145
+			Steel: 40
+			Light: 85
+			Heavy: 15
+			Concrete: 28

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -102,12 +102,14 @@ MissileTankRocket:
 	ReloadDelay: 60
 	Burst: 3
 	BurstDelays: 5
-
-MissileTankRocket_AA:
-	Inherits: AntiAirRocket
-	ReloadDelay: 60
-	Burst: 3
-	BurstDelays: 5
+	Warhead@Damage: SpreadDamage
+		Damage: 6000
+		Versus:
+			None: 5
+			Steel: 90
+			Light: 75
+			Heavy: 75
+			Concrete: 100
 
 LightAntiTankRocket:
 	Inherits: ^AntiGroundMissile
@@ -125,12 +127,12 @@ LightAntiTankRocket:
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
 		Spread: 128
-		Damage: 1500
+		Damage: 2500
 		Versus:
 			None: 10
-			Steel: 74
-			Light: 34
-			Heavy: 100
+			Steel: 75
+			Light: 80
+			Heavy: 145
 			Concrete: 50
 	Warhead@WaterEffect: CreateEffect
 		Image: water_splash_small
@@ -160,9 +162,10 @@ LightAntiAirRocket:
 		RangeLimit: 9c0
 		Speed: 341
 	Warhead@1Dam: SpreadDamage
-		Damage: 4000
+		Damage: 2500
 		Versus:
-			Light: 60
+			Light: 50
+			Heavy: 100
 
 ShipMissile:
 	Inherits: ^AntiGroundMissile
@@ -179,10 +182,10 @@ ShipMissile:
 	Warhead@1Dam: SpreadDamage
 		Damage: 700
 		Versus:
-			None: 30
+			None: 10
 			Wood: 90
 			Light: 90
-			Heavy: 115
+			Heavy: 125
 			Concrete: 100
 
 ShipMissile_AA:
@@ -200,10 +203,10 @@ ShipMissile_AA:
 	Warhead@1Dam: SpreadDamage
 		Damage: 700
 		Versus:
-			None: 30
+			None: 10
 			Wood: 90
 			Light: 90
-			Heavy: 115
+			Heavy: 125
 			Concrete: 100
 
 BoatMissile_AA:
@@ -251,15 +254,16 @@ StealthTankMissile:
 	Warhead@Damage: SpreadDamage
 		Damage: 6000
 		Versus:
-			None: 25
+			None: 10
 			Wood: 75
+			Steel: 125
 			Light: 100
 			Heavy: 90
 
 Patriot:
 	Inherits: ^AntiAirMissile
 	ReloadDelay: 55
-	Range: 15c0
+	Range: 8c0
 	Report: rocketlaunch03.wav
 	ValidTargets: Air
 	Projectile: Missile
@@ -321,7 +325,7 @@ TowerMissile:
 DropshipMissile:
 	Inherits: ^AntiGroundMissile
 	ReloadDelay: 100
-	Range: 9c0
+	Range: 8c0
 	Report: rocketlaunch01.wav
 	Burst: 6
 	BurstDelays: 6


### PR DESCRIPTION
So, this PR is supposed to address some issues with current OpenHV balance. I understand a lot of stuff was done in a rush and not properly tested. Hopefully this PR will resolve these issues. I also understand that my balance changes aren’t perfect either, but at least they should make the matches more fair and reasonable. And perhaps make the project more appealing.

PODS:

IMO pods should behave like infantry units. That means machine gun pods will be good against other pods and rocket pods will be good against vehicles/aircrafts but suck against other pods.
Also, I made technician pod to be used for both factions, so infantry count is increased.
Moreover, I slowed them down.

TURRETS:

OpenHV doesn’t have too many base defenses. So, the first turret needs to be all-rounder. I tried to be reasonable here though. Also, only arty units will be able to outrange these turrets.

Arty turrets were buffed as they barely did any damage to heavy tanks. Their spread was also increased. And requires now “techcenter”.

VEHICLES:

OK, this might be a bit controversial for you @Matze but I DO really think that adding everything which Daniel Cook drew isn’t the greatest idea ever. My main point is that every unit needs to serve a purpose and unit roles shouldn’t overlap. That means I disabled some units.

-	Hacker Tank – disabled, technician pod is just enough, PLUS Dropships/APC need to able to transport technician pods to get to areas where tech buildings are (currently only my “Doubles” map has such setup).
-	TANK3/TYRIANTANK aka Assault Tank – that should be your main spearhead tank. I made it acting like Main Battle Tank, that means it will be good against all types of units. It’s also more expensive, but more durable too.
-	Small arty unit – turns a bit faster, available for both factions.
-	AA tank – it shouldn’t require anything apart from the factory itself. It’s cheaper. I will probably make new art this one as currently it’s just ugly… And weapon range reduced.
-	Railgun tank and lighting tank are now mirrored and available for each faction. More expensive, better against everything.
-	Double arty – special YI unit. Powerful but very fragile and expensive.
-	Countermeasure tank – Armour type “light”, more expensive, requires
-	Transport – just requires module.
-	Missile tank – special SC unit. No longer AA unit (this is a job for pods/AA tanks/ships). Is somewhat better than main tanks. 
-	Repair tank – more expensive, changed repair effect to be faster and more visable.
-	Reconnaissance Tank – cheap, fragile.
-	Stealth Tank – a bit slower, good against structures. Sucks against infantry. Medium against vehicles.

SHIPS:
No much was done here, but:

-	Light Boat – it has less HP and armour type was changed to Light. It also cheaper now.
-	Medium Boat – I didn’t really think too much about this one, but it looks like a tank on water, so I just gave it the same weapon as Assault Tanks. It might be a subject for the future changes, for now, it should be enough.
-	Heavy Boat – it was lacking a prerequisite “techcenter”. As it was a bit odd having so powerful ship at once. The weapon’s range is now 8, so it won’t outrange main base turrets. Plus the gun itself is more powerful, so it should be more worth it to have it.
- 
Aircrafts:

-	Balloon and Saucer are cheap and equal
-	Planes do more damage than copters, because they have to fly around the target to shoot it.
-	Chaingun copter is better against pods, Banshee is bad against pods.
-	Both these copters are overall better against light, heavy and steel armour. In case of spamming, AA units should dispatch them.
