### PR TITLE
Sorted actors in map editor

### DIFF
--- a/mods/hv/mod.yaml
+++ b/mods/hv/mod.yaml
@@ -30,21 +30,22 @@ MapFolders:
 	~^SupportDir|maps/hv/{DEV_VERSION}: User
 
 Rules:
-	hv|rules/world.yaml
-	hv|rules/animals.yaml
-	hv|rules/defaults.yaml
-	hv|rules/vehicles.yaml
 	hv|rules/editor.yaml
 	hv|rules/player.yaml
+	hv|rules/pods.yaml
+	hv|rules/vehicles.yaml
 	hv|rules/aircraft.yaml
-	hv|rules/buildings.yaml
-	hv|rules/props.yaml
-	hv|rules/terrain.yaml
 	hv|rules/ships.yaml
+	hv|rules/animals.yaml
 	hv|rules/bonus.yaml
 	hv|rules/weapons.yaml
 	hv|rules/bots.yaml
-	hv|rules/pods.yaml
+	hv|rules/buildings.yaml
+	hv|rules/world.yaml
+	hv|rules/props.yaml
+	hv|rules/defaults.yaml
+	hv|rules/terrain.yaml
+	hv|rules/mothership.yaml
 
 Sequences:
 	hv|sequences/animals.yaml

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -341,23 +341,6 @@ BALLOON:
 	RenderSprites:
 		PlayerPalette: green
 
-MOTHER2B:
-	Inherits: ^Helicopter
-	Health:
-		HP: 800000
-	Aircraft:
-		CanHover: false
-		Speed: 0
-		CruiseAltitude: 2048
-		Repulsable: false
-		-CruisingCondition:
-	-Hovers@CRUISING:
-	Selectable:
-		DecorationBounds: 6553, 13721
-
-MOTHER2C:
-	Inherits: MOTHER2B
-
 DROPSHIP:
 	Inherits: ^Helicopter
 	Valued:
@@ -465,16 +448,19 @@ DRONE:
 		LandingDistance: 8c0
 	Rearmable:
 		RearmActors: carrier
+	-MapEditorData:
 
 DROPPOD1:
 	Inherits: ^DropPod
 	SpawnActorOnDeath:
 		Actor: scout1
+	-MapEditorData:
 
 DROPPOD2:
 	Inherits: ^DropPod
 	SpawnActorOnDeath:
 		Actor: scout2
+	-MapEditorData:
 
 LANDEDPOD:
 	Inherits: ^Prop
@@ -496,3 +482,4 @@ LANDEDPOD:
 	-ThrowsShrapnel:
 	RenderSprites:
 		PlayerPalette: green
+	-MapEditorData:

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -1048,6 +1048,60 @@ AATURRET2:
 	RenderSprites:
 		PlayerPalette: green
 
+ARTILLERYTURRET:
+	Inherits: ^DefenseBuilding
+	Inherits@AutoTarget: ^AutoTargetGround
+	Selectable:
+		Bounds: 2048, 2048
+	Buildable:
+		BuildPaletteOrder: 90
+		Prerequisites: factory, techcenter
+		Description: Advanced base defense.\nRequires power to operate.
+	Valued:
+		Cost: 2000
+	Tooltip:
+		Name: Artillery Turret
+	Building:
+		Footprint: xx xx
+		Dimensions: 2,2
+	HitShape:
+		UseTargetableCellsOffsets: False
+		TargetableOffsets: -256,-256,0,   256,-256,0,   -256,256,0,   256,256,0
+	Health:
+		HP: 60000
+	RevealsShroud:
+		Range: 12c0
+		MinRange: 4c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Offline:
+		RequiresCondition: !disabled
+		Range: 5c0
+		MinRange: 4c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 4c0
+	Power:
+		Amount: -120
+	Armament:
+		Weapon: TurretArtillery
+		LocalOffset: 1500,50,1400
+	WithRangeCircle:
+		Type: Turret
+		Width: 2
+		BorderWidth: 3
+		Range: 20c0
+	AttackTurreted:
+		PauseOnCondition: disabled || beam-incomplete
+	WithSpriteTurret:
+		RequiresCondition: !build-incomplete
+	WithTurretAttackAnimation:
+		Sequence: shoot
+	Turreted:
+		TurnSpeed: 60
+		RequiresCondition: !build-incomplete
+	RenderSprites:
+		PlayerPalette: green
+
 FIELD:
 	Inherits: ^BaseBuilding
 	Inherits@Disable: ^DisableOnLowPowerOrPowerDown
@@ -1414,61 +1468,6 @@ REFINERY:
 		RequiresCondition: build-incomplete
 		PauseOnCondition: !build-incomplete
 
-ARTILLERYTURRET:
-	Inherits: ^DefenseBuilding
-	Inherits@AutoTarget: ^AutoTargetGround
-	Selectable:
-		Bounds: 2048, 2048
-	Buildable:
-		BuildPaletteOrder: 90
-		Prerequisites: factory, techcenter
-		Description: Advanced base defense.\nRequires power to operate.
-	Valued:
-		Cost: 2000
-	Tooltip:
-		Name: Artillery Turret
-	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
-	HitShape:
-		UseTargetableCellsOffsets: False
-		TargetableOffsets: -256,-256,0,   256,-256,0,   -256,256,0,   256,256,0
-	Health:
-		HP: 60000
-	RevealsShroud:
-		Range: 12c0
-		MinRange: 4c0
-		RevealGeneratedShroud: False
-	RevealsShroud@Offline:
-		RequiresCondition: !disabled
-		Range: 5c0
-		MinRange: 4c0
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 4c0
-	Power:
-		Amount: -120
-	Armament:
-		Weapon: TurretArtillery
-		LocalOffset: 1500,50,1400
-	WithRangeCircle:
-		Type: Turret
-		Width: 2
-		BorderWidth: 3
-		Range: 20c0
-	AttackTurreted:
-		PauseOnCondition: disabled || beam-incomplete
-	WithSpriteTurret:
-		RequiresCondition: !build-incomplete
-	WithTurretAttackAnimation:
-		Sequence: shoot
-	Turreted:
-		TurnSpeed: 60
-		RealignDelay: -1
-		RequiresCondition: !build-incomplete
-	RenderSprites:
-		PlayerPalette: green
-
 TELEVATR:
 	Inherits: ^BaseBuilding
 	Inherits@Disable: ^DisableOnLowPowerOrPowerDown
@@ -1655,32 +1654,6 @@ HARBOR:
 		PlayerExperience: 15
 		StartRepairingNotification: Repairing
 		FinishRepairingNotification: UnitRepaired
-
-MOTHER:
-	Inherits: ^BaseBuilding
-	Inherits@Shape: ^6x8Shape
-	Selectable:
-		Bounds: 5785, 7424
-	Valued:
-		Cost: 15000
-	Tooltip:
-		Name: Mother Ship
-	Building:
-		Footprint: xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx
-		Dimensions: 6,8
-	Health:
-		HP: 5000000
-	Armor:
-		Type: Steel
-	RevealsShroud:
-		Range: 16c0
-		MinRange: 4c0
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 4c0
-	StrategicPoint:
-	ProximityCapturable:
-	RenderSprites:
 
 WALLTOP:
 	Inherits: ^Wall

--- a/mods/hv/rules/mothership.yaml
+++ b/mods/hv/rules/mothership.yaml
@@ -1,0 +1,48 @@
+# License: CC-BY-SA-4.0
+
+MOTHER2B:
+	Inherits: ^Helicopter
+	Health:
+		HP: 800000
+	Aircraft:
+		CanHover: false
+		Speed: 0
+		CruiseAltitude: 2048
+		Repulsable: false
+		-CruisingCondition:
+	-Hovers@CRUISING:
+	Selectable:
+		DecorationBounds: 6553, 13721
+	MapEditorData:
+		Categories: Mothership
+
+MOTHER2C:
+	Inherits: MOTHER2B
+
+MOTHER:
+	Inherits: ^BaseBuilding
+	Inherits@Shape: ^6x8Shape
+	Selectable:
+		Bounds: 5785, 7424
+	Valued:
+		Cost: 15000
+	Tooltip:
+		Name: Mother Ship
+	Building:
+		Footprint: xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx
+		Dimensions: 6,8
+	Health:
+		HP: 5000000
+	Armor:
+		Type: Steel
+	RevealsShroud:
+		Range: 16c0
+		MinRange: 4c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 4c0
+	StrategicPoint:
+	ProximityCapturable:
+	RenderSprites:
+	MapEditorData:
+		Categories: Mothership


### PR DESCRIPTION
Sorted yaml rules, disabled drones and droppods from map editor, moved motherships to own yaml.

![mapeditor](https://user-images.githubusercontent.com/17529329/131750465-46c9a3e0-1da0-48c1-80d6-c67e81b762a3.gif)
