### PR TITLE
Balance changes

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -31,20 +31,21 @@ SHIP2:
 		MuzzleSequence: muzzle
 	AttackAircraft:
 		FacingTolerance: 20
-		PersistentTargeting: false
-		OpportunityFire: false
+		PersistentTargeting: False
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 768
-		TurnSpeed: 16
-		Speed: 180
+		TurnSpeed: 20
+		Speed: 220
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	Voiced:
 		VoiceSet: GunshipVoice
 	AutoTarget:
-		InitialStance: HoldFire
-		InitialStanceAI: HoldFire
+		InitialStance: Defend
+		InitialStanceAI: AttackAnything
+	AutoTargetPriority:
+		InvalidTargets: Structure
 	WithMuzzleOverlay:
 	Contrail:
 		Offset: -400,0,0
@@ -86,19 +87,20 @@ SHIP1:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
-		OpportunityFire: false
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 768
-		TurnSpeed: 16
-		Speed: 180
+		TurnSpeed: 20
+		Speed: 220
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	Voiced:
 		VoiceSet: SpeederVoice
 	AutoTarget:
-		InitialStance: HoldFire
-		InitialStanceAI: HoldFire
+		InitialStance: Defend
+		InitialStanceAI: AttackAnything
+	AutoTargetPriority:
+		InvalidTargets: Structure
 	Selectable:
 		Bounds: 1024, 1024
 	Contrail:
@@ -173,7 +175,7 @@ SAUCER:
 	Health:
 		HP: 8000
 	RevealsShroud:
-		Range: 16c0
+		Range: 18c0
 		Type: GroundPosition
 		MinRange: 4c0
 		RevealGeneratedShroud: False
@@ -221,7 +223,7 @@ BANSHEE:
 		Range: 4c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 16
+		TurnSpeed: 20
 		Speed: 112
 	Voiced:
 		VoiceSet: BansheeVoice
@@ -315,7 +317,7 @@ BALLOON:
 	Health:
 		HP: 8000
 	RevealsShroud:
-		Range: 16c0
+		Range: 18c0
 		Type: GroundPosition
 		MinRange: 4c0
 		RevealGeneratedShroud: False

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -31,12 +31,12 @@ SHIP2:
 		MuzzleSequence: muzzle
 	AttackAircraft:
 		FacingTolerance: 20
-		PersistentTargeting: False
+		PersistentTargeting: false
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 768
 		TurnSpeed: 20
-		Speed: 220
+		Speed: 200
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	Voiced:
@@ -91,7 +91,7 @@ SHIP1:
 		CruiseAltitude: 2560
 		InitialFacing: 768
 		TurnSpeed: 20
-		Speed: 220
+		Speed: 200
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	Voiced:

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -442,6 +442,8 @@ MINER2:
 		Name: Mining Tower
 	Valued:
 		Cost: 1000
+	Health:
+		HP: 45000
 	ProvidesPrerequisite@BuildingName:
 	ResourceCollector:
 		Interval: 100
@@ -905,7 +907,7 @@ TURRET:
 	Tooltip:
 		Name: Turret
 	Health:
-		HP: 50000
+		HP: 55000
 	Armament:
 		Weapon: TurretCannon
 		LocalOffset: 1200,50,0
@@ -938,7 +940,7 @@ TURRET2:
 	Tooltip:
 		Name: Turret
 	Health:
-		HP: 50000
+		HP: 55000
 	Armament:
 		Name: primary
 		Weapon: Turret2Cannon
@@ -981,6 +983,8 @@ AATURRET:
 		Cost: 1250
 	Tooltip:
 		Name: AA Turret
+	Health:
+		HP: 55000
 	Armor:
 		Type: Steel
 	Armament:
@@ -1025,7 +1029,7 @@ AATURRET2:
 	Tooltip:
 		Name: AA Turret
 	Health:
-		HP: 45000
+		HP: 55000
 	Armament:
 		Weapon: TowerMissile
 		LocalOffset: 256,375,760, 256,-375,760
@@ -1068,7 +1072,7 @@ ARTILLERYTURRET:
 		UseTargetableCellsOffsets: False
 		TargetableOffsets: -256,-256,0,   256,-256,0,   -256,256,0,   256,256,0
 	Health:
-		HP: 60000
+		HP: 65000
 	RevealsShroud:
 		Range: 12c0
 		MinRange: 4c0
@@ -1384,7 +1388,7 @@ REFINERY:
 	Tooltip:
 		Name: Refinery
 	Health:
-		HP: 30000
+		HP: 55000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -1579,7 +1583,7 @@ HARBOR:
 		Dimensions: 3,3
 		TerrainTypes: Littoral
 	Health:
-		HP: 35000
+		HP: 40000
 	Armor:
 		Type: Steel
 	RevealsShroud:

--- a/mods/hv/weapons/ballistics.yaml
+++ b/mods/hv/weapons/ballistics.yaml
@@ -122,8 +122,8 @@ TurretCannon:
 		Versus:
 			None: 40
 			Steel: 100
-			Light: 125
-			Heavy: 150
+			Light: 150
+			Heavy: 175
 	Warhead@GroundEffect: CreateEffect
 		Explosions: small
 		ValidTargets: Ground
@@ -157,6 +157,11 @@ Turret2Cannon:
 		DamageTypes: Fire
 		Spread: 128
 		Damage: 2500
+		Versus:
+			None: 40
+			Steel: 100
+			Light: 150
+			Heavy: 175
 
 Nuclear:
 	ValidTargets: Ground, Air, Tree, Lava, Swamp
@@ -241,10 +246,10 @@ TurretArtillery:
 		Damage: 30000
 		Spread: 750
 		Versus:
-			None: 60
-			Steel: 50
-			Light: 60
-			Heavy: 60
+			None: 150
+			Steel: 65
+			Light: 65
+			Heavy: 65
 			Wood: 40
 	Warhead@Effect: CreateEffect
 		Explosions: large

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -142,10 +142,10 @@ Plasma:
 		Damage: 1200
 		ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
 		Versus:
-			None: 10
-			Steel: 74
+			None: 15
+			Steel: 85
 			Light: 75
-			Heavy: 125
+			Heavy: 175
 			Concrete: 50
 	Warhead@Effect: CreateEffect
 		Explosions: small

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -10,10 +10,10 @@ LightMachineGun:
 		Damage: 1000
 		Versus:
 			None: 150
-			Steel: 25
+			Steel: 10
 			Light: 30
 			Heavy: 10
-			Concrete: 10
+			Concrete: 5
 	Warhead@Effect: CreateEffect
 		Image: hit
 		Explosions: spark_a, spark_b, spark_c, spark_d
@@ -64,10 +64,10 @@ ChainGun:
 		Damage: 1000
 		Versus:
 			None: 180
-			Steel: 60
-			Light: 70
+			Steel: 30
+			Light: 65
 			Heavy: 35
-			Concrete: 28
+			Concrete: 15
 	Warhead@Effect: CreateEffect
 		Image: hit
 		Explosions: spark_a, spark_b, spark_c, spark_d
@@ -166,7 +166,7 @@ SniperRifle:
 	Warhead@Damage: SpreadDamage
 		Spread: 24
 		Versus:
-			None: 1000
+			None: 1500
 			Steel: 40
 			Light: 55
 			Heavy: 25


### PR DESCRIPTION
I recommend testing these changes. Exact values you can see on github.

1. Pods are less effective against buildings.
2. Anti-tank turrets have more HP and do a bit more damage against vehicles.
3. Refinery and Miner building have now more HP.
4. Planes are faster and auto attack actors, but ignore buildings.
5. Banshee does more damage against buildings and vehicles to compensate their slow speed.
6. Copters do not less damage against buildings and light vehicles.
7. Artillery turrets do more damage against everything.
8. AA turrets have now the same amount of HP.
9. Increased balloon's and saucer's reveal shroud range by 2 tiles.
10. Sniper pods now one shot kill other pods.