### PR TITLE
Small faction powers adjustment

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -271,7 +271,7 @@ RADAR:
 	AirstrikePower:
 		PauseOnCondition: lowpower
 		Icon: airstrike
-		ChargeInterval: 7500
+		ChargeInterval: 3750
 		SquadSize: 3
 		QuantizedFacings: 8
 		Description: Air Strike
@@ -300,11 +300,11 @@ RADAR2:
 		Description: Drop Pods
 		LongDesc: Atmospheric assault reinforcements.\nSmall team of pods drops\nonto target location from orbit.
 		DisplayRadarPing: true
-		ChargeInterval: 10000
+		ChargeInterval: 3750
 		UnitTypes: droppod1, droppod2
 		CameraActor: camera
 		PodScatter: 5
-		Drops: 8,8
+		Drops: 12,12
 		OrderName: EjectPods
 		SelectTargetSound: select_target.wav
 


### PR DESCRIPTION
Airstrike and Droppod charger interval changed to from 5 to 2.5 min.
Added 4 additional pods for Droppod power.