### PR TITLE
Adjusted AA turrets

### DIFF
--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -204,7 +204,6 @@ VoltageArc:
 LightningBolt:
 	ReloadDelay: 50
 	Range: 9c0
-	MinRange: 1c0
 	Report: lightningbolt.wav
 	ValidTargets: Air
 	Projectile: EnergyBolt
@@ -219,7 +218,7 @@ LightningBolt:
 		ZOffset: 2000
 	Warhead@Damage: SpreadDamage
 		Spread: 128
-		Damage: 2500
+		Damage: 3250
 		ValidTargets: Air
 		Versus:
 			None: 30

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -301,7 +301,7 @@ Patriot:
 
 TowerMissile:
 	Inherits: ^AntiAirMissile
-	ReloadDelay: 55
+	ReloadDelay: 50
 	Range: 9c0
 	Report: rocketlaunch03.wav
 	ValidTargets: Air

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -309,7 +309,7 @@ TowerMissile:
 		Arm: 1
 		VerticalRateOfTurn: 140
 		RangeLimit: 25c0
-		Speed: 288
+		Speed: 350
 		MinimumLaunchSpeed: 75
 		MaximumLaunchSpeed: 96
 		Blockable: false
@@ -323,8 +323,14 @@ TowerMissile:
 		AllowSnapping: true
 	Warhead@Damage: SpreadDamage
 		Spread: 128
-		Damage: 6000
-		ValidTargets: Air, Ground, Lava, Swamp
+		Damage: 3250
+		ValidTargets: Air
+		Versus:
+			None: 30
+			Wood: 90
+			Light: 90
+			Heavy: 115
+			Concrete: 100
 	Warhead@Effect: CreateEffect
 		Explosions: small
 		ImpactSounds: explosion08.wav


### PR DESCRIPTION
Both turrets deal the same amount of damage now.

AA turrets are now stronger (4 shots are required to kill a copter instead of 5).

Missile projectile is faster (from 288 to 350).

Removed `MinRange` for lightning turret.