### PR TITLE
Small adjustments

### DIFF
--- a/mods/hv/sequences/aircraft.yaml
+++ b/mods/hv/sequences/aircraft.yaml
@@ -149,3 +149,4 @@ landedpod:
 bomber1:
 	idle: bits/bomber1.png
 		Facings: 8
+		ZOffset: 2050

--- a/mods/hv/sequences/aircraft.yaml
+++ b/mods/hv/sequences/aircraft.yaml
@@ -149,4 +149,4 @@ landedpod:
 bomber1:
 	idle: bits/bomber1.png
 		Facings: 8
-		ZOffset: 2050
+		ZOffset: 2048

--- a/mods/hv/weapons/ballistics.yaml
+++ b/mods/hv/weapons/ballistics.yaml
@@ -71,6 +71,7 @@
 	Warhead@Effect: CreateEffect
 		Explosions: large
 		ImpactSounds: explosion04.wav, explosion05.wav
+		ValidTargets: Ground, Tree
 
 SmallArtillery:
 	Inherits: ^Artillery

--- a/mods/hv/weapons/bombs.yaml
+++ b/mods/hv/weapons/bombs.yaml
@@ -27,7 +27,7 @@ Bomb:
 			Wood: 75
 	Warhead@GroundEffect: CreateEffect
 		Explosions: medium
-		ValidTargets: Ground
+		ValidTargets: Ground, Tree
 		ImpactSounds: explosion06.wav
 	Warhead@WaterEffect: CreateEffect
 		Image: water_splash

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -229,7 +229,7 @@ LightningBolt:
 	Warhead@Effect: CreateEffect
 		Explosions: small
 		ImpactSounds: explosion06.wav
-		ValidTargets: Ground, Air, Ship, Tree, Lava, Swamp
+		ValidTargets: Air
 	Warhead@Sparks: FireShrapnel
 		Weapon: ElectricSpark
 		Amount: 4

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -293,7 +293,7 @@ Patriot:
 	Warhead@Damage: SpreadDamage
 		Spread: 128
 		Damage: 6000
-		ValidTargets: Air, Ground, Lava, Swamp
+		ValidTargets: Air
 	Warhead@Effect: CreateEffect
 		Explosions: small
 		ImpactSounds: explosion08.wav


### PR DESCRIPTION
AA weapons now damage only air units (if an actor was above a building, it was damaged as well, lol).

Adjusted ZOffset for Bombers, their bombs will now appear below them.

Bombers' bombs now explode when they hit trees.

Artillery's projectiles now explode when they hit trees.