### PR TITLE
Disabled `OpportunityFire` for planes

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -32,6 +32,7 @@ PLANE1:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
+		OpportunityFire: False
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 768
@@ -87,6 +88,7 @@ PLANE2:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
+		OpportunityFire: False
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 768

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -32,7 +32,7 @@ PLANE1:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
-		OpportunityFire: False
+		OpportunityFire: false
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 768
@@ -88,7 +88,7 @@ PLANE2:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
-		OpportunityFire: False
+		OpportunityFire: false
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 768


### PR DESCRIPTION
I actually readded that, as I didn't realize planes would shoot targets while flying above them without ordering the attack.

However if they left alone, they attack foes as intended.