### PR TITLE
Adjusted Turret2 weapons

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -985,14 +985,17 @@ TURRET2:
 		Name: Turret
 	Health:
 		HP: 55000
-	Armament:
+	Armament@PRIMARY:
 		Name: primary
-		Weapon: Turret2Cannon
+		Weapon: Turret2CannonFirst
 		LocalOffset: 600,-300,300
 	Armament@SECONDARY:
 		Name: secondary
-		Weapon: Turret2Cannon
+		Weapon: Turret2CannonSecond
 		LocalOffset: 600,200,300
+	Armament@TERRIARY:
+		Name: tertiary
+		Weapon: Turret2CannonFake
 	WithRangeCircle:
 		Type: Turret
 		Width: 2
@@ -1000,6 +1003,7 @@ TURRET2:
 		Range: 8c0
 	AttackTurreted:
 		PauseOnCondition: disabled
+		Armaments: primary, secondary, tertiary
 		RequiresCondition: !build-incomplete && !beam-incomplete
 	WithSpriteTurret:
 		RequiresCondition: !build-incomplete

--- a/mods/hv/sequences/weapons.yaml
+++ b/mods/hv/sequences/weapons.yaml
@@ -289,3 +289,6 @@ shells:
 		Start: 3
 		Tick: 3000
 		ZOffset: -100
+
+null:
+	idle: null.png

--- a/mods/hv/weapons/ballistics.yaml
+++ b/mods/hv/weapons/ballistics.yaml
@@ -148,11 +148,13 @@ TurretCannon:
 		InvalidTargets: Ship, Structure
 		ImpactSounds: Video_Game_Splash-Ploor.wav
 
-Turret2Cannon:
-	Inherits: TurretCannon
-	Report: blaster-newlocknew.wav
+Turret2CannonFirst:
+	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	ReloadDelay: 25
+	Range: 8c0
 	Projectile: Bullet
-		Image: bullet9
+		Speed: 682
+		Image: bullet3
 		Shadow: false
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
@@ -163,6 +165,55 @@ Turret2Cannon:
 			Steel: 100
 			Light: 150
 			Heavy: 175
+	Warhead@GroundEffect: CreateEffect
+		Explosions: small
+		ValidTargets: Ground
+		ImpactSounds: explosion02.wav
+	Warhead@WaterEffect: CreateEffect
+		Image: water_splash
+		Explosions: water_splash_a, water_splash_b
+		ValidTargets: Water
+		InvalidTargets: Ship, Structure
+		ImpactSounds: Video_Game_Splash-Ploor.wav
+	Warhead@LavaEffect: CreateEffect
+		Image: lava_splash
+		Explosions: lava_splash_a, lava_splash_b
+		ValidTargets: Lava
+		InvalidTargets: Ship, Structure
+		ImpactSounds: Video_Game_Splash-Ploor.wav
+	Warhead@SwampEffect: CreateEffect
+		Image: swamp_splash
+		Explosions: swamp_splash_a, swamp_splash_b
+		ValidTargets: Swamp
+		InvalidTargets: Ship, Structure
+		ImpactSounds: Video_Game_Splash-Ploor.wav
+
+Turret2CannonSecond:
+	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	ReloadDelay: 25
+	Range: 8c0
+	Projectile: Bullet
+		Speed: 682
+		Image: bullet3
+		Shadow: false
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		Spread: 128
+		Damage: 2500
+		Versus:
+			None: 40
+			Steel: 100
+			Light: 150
+			Heavy: 175
+
+Turret2CannonFake:
+	Inherits: Turret2CannonSecond
+	Report: blaster-newlocknew.wav
+	Projectile: Bullet
+		Image: null
+		Shadow: false
+	Warhead@Damage: SpreadDamage
+		Damage: 0
 
 Nuclear:
 	ValidTargets: Ground, Air, Tree, Lava, Swamp


### PR DESCRIPTION
Now, this is an experimental change. Sadly, OpenRA stacks sounds, so two triggered sounds at the same time will be unnecessarily loud.

So this PR adds 3rd armament, which is fake and only produces actual gun fire sound, while two other main guns are soundless, plus only the first armament produces sound effects when a projectile hits something.