### PR TITLE
Brought back Base2

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -58,6 +58,8 @@ BASE:
 		Files: Quedicemipez__teleportation.wav
 	RenderSprites:
 		PlayerPalette: green
+		FactionImages:
+			sc: base2
 	WithIdleOverlay@Shadow:
 		Sequence: shadow-overlay
 		Palette: shadow


### PR DESCRIPTION
Matze, when you changed all filenames and code to use generic names for building actors, you accidently removed `FactionImages` for the Base, so SC variant would be never rendered.