### PR TITLE
Adjusted RevealsShroud for a lot of actors

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -19,8 +19,8 @@ PLANE1:
 		HP: 10000
 	RevealsShroud:
 		Range: 10c0
-		Type: GroundPosition
 		MinRange: 4c0
+		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
@@ -76,9 +76,9 @@ PLANE2:
 	Health:
 		HP: 10000
 	RevealsShroud:
-		Range: 10c0
-		Type: GroundPosition
+		Range: 11c0
 		MinRange: 4c0
+		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
@@ -136,8 +136,8 @@ COPTER:
 		HP: 10000
 	RevealsShroud:
 		Range: 10c0
-		Type: GroundPosition
 		MinRange: 4c0
+		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
@@ -181,11 +181,11 @@ SAUCER:
 		HP: 8000
 	RevealsShroud:
 		Range: 18c0
+		MinRange: 6c0
 		Type: GroundPosition
-		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
 		TurnSpeed: 16
@@ -220,9 +220,9 @@ BANSHEE:
 	Health:
 		HP: 10000
 	RevealsShroud:
-		Range: 10c0
-		Type: GroundPosition
+		Range: 11c0
 		MinRange: 4c0
+		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
@@ -260,8 +260,8 @@ COPTER2:
 		HP: 15000
 	RevealsShroud:
 		Range: 8c0
-		Type: GroundPosition
 		MinRange: 4c0
+		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
@@ -318,11 +318,11 @@ BALLOON:
 		HP: 8000
 	RevealsShroud:
 		Range: 18c0
+		MinRange: 6c0
 		Type: GroundPosition
-		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
 		Speed: 70
@@ -360,8 +360,8 @@ DROPSHIP:
 		HP: 15000
 	RevealsShroud:
 		Range: 8c0
-		Type: GroundPosition
 		MinRange: 4c0
+		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
@@ -420,12 +420,12 @@ DROPSHIP.Husk:
 		SpawnAtLastPosition: false
 		Type: CenterPosition
 	RevealsShroud:
-		MinRange: 8c0
 		Range: 4c0
+		MinRange: 2c0
 		Type: GroundPosition
 		RevealGeneratedShroud: false
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 		Type: GroundPosition
 	RenderSprites:
 		Image: dropship
@@ -443,11 +443,11 @@ DRONE:
 		Type: Light
 	RevealsShroud:
 		Range: 4c0
+		MinRange: 2c0
 		Type: GroundPosition
-		MinRange: 1c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 1c0
+		Range: 2c0
 		Type: GroundPosition
 	Armament:
 		Weapon: DroneBlaster

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -201,10 +201,10 @@ GENERATOR:
 		Type: Steel
 	RevealsShroud:
 		Range: 4c0
-		MinRange: 4c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	Power:
 		Amount: 130
 	Targetable:
@@ -261,7 +261,6 @@ RADAR:
 	RevealsShroud@Offline:
 		Range: 5c0
 		RequiresCondition: disabled
-		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
@@ -361,10 +360,10 @@ TRADPLAT:
 		Type: Steel
 	RevealsShroud:
 		Range: 5c0
-		MinRange: 4c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	Reservable:
 	RallyPoint:
 		IsPlayerPalette: true
@@ -424,10 +423,10 @@ MODULE:
 		Type: Steel
 	RevealsShroud:
 		Range: 5c0
-		MinRange: 4c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	RallyPoint:
 		IsPlayerPalette: true
 		Palette: green
@@ -542,7 +541,7 @@ MINER2:
 	-RequiresBuildableArea:
 	-GivesBuildableArea:
 	RevealsShroud:
-		Range: 4c0
+		Range: 5c0
 		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
@@ -583,10 +582,10 @@ STARPORT:
 		Type: Steel
 	RevealsShroud:
 		Range: 5c0
-		MinRange: 4c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	Exit:
 		RequiresCondition: !being-captured && !build-incomplete
 		SpawnOffset: 0,-256,0
@@ -681,11 +680,11 @@ FACTORY3:
 	Armor:
 		Type: Steel
 	RevealsShroud:
-		Range: 4c768
-		MinRange: 4c0
+		Range: 5c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	Power:
 		Amount: -150
 	ProvidesPrerequisite@BuildingName:
@@ -948,7 +947,7 @@ TECHCENTER:
 	Armor:
 		Type: Steel
 	RevealsShroud:
-		Range: 4c0
+		Range: 5c0
 		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
@@ -1002,6 +1001,8 @@ BUNKER:
 	HitShape:
 		Type: Circle
 			Radius: 512
+	RevealsShroud:
+		Range: 7c0
 	WithRangeCircle:
 		Type: Turret
 		Width: 2
@@ -1049,6 +1050,8 @@ TURRET:
 		Width: 2
 		BorderWidth: 3
 		Range: 8c0
+	RevealsShroud:
+		Range: 7c0
 	AttackTurreted:
 		PauseOnCondition: disabled
 		RequiresCondition: !build-incomplete && !beam-incomplete
@@ -1200,13 +1203,12 @@ HOWITZER:
 	Health:
 		HP: 100000
 	RevealsShroud:
-		Range: 12c0
+		Range: 8c0
 		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Offline:
 		RequiresCondition: !disabled
 		Range: 5c0
-		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
@@ -1496,11 +1498,11 @@ STORAGE:
 	Armor:
 		Type: Steel
 	RevealsShroud:
-		Range: 4c0
-		MinRange: 4c0
+		Range: 5c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	Power:
 		Amount: -30
 	RenderSprites:
@@ -1595,12 +1597,12 @@ TELEVATR:
 	Armor:
 		Type: Steel
 	RevealsShroud:
-		Range: 6c0
+		Range: 5c0
+		MinRange: 2c0
 		RequiresCondition: !disabled
-		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	Power:
 		Amount: -200
 	MustBeDestroyed:
@@ -1686,11 +1688,11 @@ HARBOR:
 	Armor:
 		Type: Steel
 	RevealsShroud:
-		Range: 4c768
-		MinRange: 4c0
+		Range: 5c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	RallyPoint:
 		Path: 1,3
 		IsPlayerPalette: true
@@ -2104,17 +2106,16 @@ TECHBUILDING:
 	Armor:
 		Type: Steel
 	RevealsShroud:
-		Range: 10c0
-		MinRange: 4c0
+		Range: 4c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 		RequiresCondition: !disabled && !ownerless
 	RevealsShroud@Offline:
-		Range: 5c0
-		MinRange: 4c0
+		Range: 2c0
 		RevealGeneratedShroud: False
 		RequiresCondition: disabled && !ownerless
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	Power:
 		Amount: -40
 		RequiresCondition: !ownerless
@@ -2230,17 +2231,16 @@ TECHMINER:
 	WithSpriteBody:
 		PauseOnCondition: disabled
 	RevealsShroud:
-		Range: 10c0
-		MinRange: 4c0
+		Range: 4c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 		RequiresCondition: !disabled && !ownerless
 	RevealsShroud@Offline:
-		Range: 5c0
-		MinRange: 4c0
+		Range: 2c0
 		RevealGeneratedShroud: False
 		RequiresCondition: disabled && !ownerless
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	RenderSprites:
 		PlayerPalette: green
 	MustBeDestroyed:
@@ -2306,17 +2306,16 @@ TECHCOMLINK:
 		Amount: -40
 		RequiresCondition: !ownerless
 	RevealsShroud:
-		Range: 10c0
-		MinRange: 4c0
-		RevealGeneratedShroud: false
+		Range: 6c0
+		MinRange: 3c0
+		RevealGeneratedShroud: False
 		RequiresCondition: !disabled && !ownerless
 	RevealsShroud@Offline:
-		Range: 5c0
-		MinRange: 4c0
+		Range: 3c0
 		RevealGeneratedShroud: False
 		RequiresCondition: disabled && !ownerless
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	RenderSprites:
 		PlayerPalette: green
 	MustBeDestroyed:

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -165,6 +165,12 @@
 	Crushable:
 		CrushClasses: Pods
 		WarnProbability: 15
+	RevealsShroud:
+		Range: 4c0
+		MinRange: 2c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 2c0
 
 ^Scrap:
 	Interactable:
@@ -509,14 +515,13 @@
 	Armor:
 		Type: Steel
 	RevealsShroud:
-		Range: 10c0
+		Range: 8c0
 		MinRange: 4c0
 		RevealGeneratedShroud: False
 		RequiresCondition: !build-incomplete && !beam-incomplete
 	RevealsShroud@Offline:
 		RequiresCondition: !disabled
 		Range: 5c0
-		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0

--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -13,12 +13,6 @@ SCOUT1:
 		Name: Machine Gun Pod
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
-	RevealsShroud:
-		Range: 7c0
-		MinRange: 4c0
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 4c0
 	Armament@Primary:
 		Weapon: LightMachineGun
 		MuzzleSequence: muzzle
@@ -45,12 +39,6 @@ SCOUT2:
 		Name: Rocket Pod
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
-	RevealsShroud:
-		Range: 7c0
-		MinRange: 4c0
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 4c0
 	Armament@Primary:
 		Weapon: LightAntiTankRocket
 		MuzzleSequence: muzzle
@@ -82,12 +70,6 @@ MORTARPOD:
 		Name: Mortar Pod
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
-	RevealsShroud:
-		Range: 7c0
-		MinRange: 4c0
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 4c0
 	Armament@Primary:
 		Weapon: mortargun
 		MuzzleSequence: muzzle
@@ -125,10 +107,6 @@ SNIPERPOD:
 		Locomotor: pod
 	RevealsShroud:
 		Range: 8c0
-		MinRange: 4c0
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 4c0
 	Armament@Primary:
 		Weapon: SniperRifle
 		MuzzleSequence: muzzle
@@ -173,9 +151,3 @@ TECHNICIAN:
 		Voice: Move
 	RenderSprites:
 		PlayerPalette: green
-	RevealsShroud:
-		Range: 6c0
-		MinRange: 4c0
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 4c0

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -70,11 +70,11 @@ BOAT:
 		Speed: 100
 		TurnSpeed: 60
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 6c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Turreted:
 		TurnSpeed: 60
 		Offset: 150,0,100
@@ -114,18 +114,18 @@ BOAT2:
 		Speed: 75
 		TurnSpeed: 40
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 6c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Turreted:
 		TurnSpeed: 40
 	Armament:
 		Weapon: railgun
 		Recoil: 100
 		RecoilRecovery: 25
-		LocalOffset: 500,0,0 # TODO: to be adjusted
+		LocalOffset: 500,0,0
 	AttackTurreted:
 	WithSpriteTurret:
 	RenderSprites:
@@ -155,11 +155,11 @@ BOAT4:
 		Speed: 55
 		TurnSpeed: 40
 	RevealsShroud:
-		Range: 10c0
-		MinRange: 4c0
+		Range: 7c0
+		MinRange: 3c0
 		RevealGeneratedShroud: false
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	AttackFrontal:
 		FacingTolerance: 25
 	WithMissileSpawnerParentPipsDecoration:
@@ -236,8 +236,8 @@ CARRIER:
 		Type: Heavy
 	RevealsShroud:
 		Range: 7c0
+		MinRange: 3c0
 		Type: CenterPosition
-		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
@@ -249,6 +249,9 @@ CARRIER:
 		Voice: Move
 	RevealsShroud:
 		Range: 7c0
+		RevealGeneratedShroud: false
+	RevealsShroud@Hacked:
+		Range: 3c0
 	AttackFrontal:
 		FacingTolerance: 128
 	RenderSprites:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -22,11 +22,11 @@ TANK3:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 6c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Turreted:
 		TurnSpeed: 25
 		Offset: -125,0,50
@@ -45,48 +45,13 @@ TANK3:
 		PlayerPalette: green
 
 TYRIANTANK:
-	Inherits: ^TrackedVehicle
-	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
-	Valued:
-		Cost: 850
-	Tooltip:
-		Name: Assault Tank
-		GenericName: Tank
+	Inherits: TANK3
 	Buildable:
-		Queue: Vehicle
 		Prerequisites: ~factory.sc
-		BuildPaletteOrder: 10
-		Description: Main Battle Tank.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 46000
-	Armor:
-		Type: Heavy
-	Mobile:
-		TurnSpeed: 25
-		Speed: 100
-	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 4c0
 	Turreted:
-		TurnSpeed: 25
+		Offset: 0,0,0
 	Armament:
-		Weapon: ^Cannon
-		Recoil: 125
-		RecoilRecovery: 38
-		MuzzleSequence: muzzle
 		LocalOffset: 550,-50,0
-	AttackTurreted:
-		PauseOnCondition: ecmdisabled
-		Voice: Attack
-	WithSpriteTurret:
-	WithMuzzleOverlay:
-	RenderSprites:
-		PlayerPalette: green
 
 AATANK:
 	Inherits: ^TrackedVehicle
@@ -111,11 +76,11 @@ AATANK:
 		Speed: 115
 		Locomotor: lighttracked
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 6c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Turreted:
 		TurnSpeed: 40
 	Armament:
@@ -165,11 +130,11 @@ TRANSPRT:
 		Speed: 110
 		PauseOnCondition: notmobile || ecmdisabled
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 5c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	Cargo:
 		Types: Scout
 		MaxWeight: 5
@@ -212,11 +177,11 @@ ARTIL:
 		Speed: 95
 		Locomotor: lighttracked
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 4c0
+		Range: 5c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Armament:
 		Weapon: SmallArtillery
 		MuzzleSequence: muzzle
@@ -263,7 +228,7 @@ RADARTANK:
 		RequireForceMoveCondition: !undeployed
 	RevealsShroud:
 		RequiresCondition: undeployed
-		Range: 6c0
+		Range: 8c0
 		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
@@ -271,7 +236,7 @@ RADARTANK:
 		RequiresCondition: undeployed
 	RevealsShroud@DEPLOYED:
 		RequiresCondition: !undeployed
-		Range: 12c0
+		Range: 14c0
 	WithMakeAnimation:
 		Sequence: extend
 		BodyNames: deployed
@@ -334,10 +299,10 @@ TANK16:
 		TurnSpeed: 25
 	RevealsShroud:
 		Range: 6c0
-		MinRange: 4c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	AutoTarget:
 		ScanRadius: 8
 		InitialStance: AttackAnything
@@ -367,11 +332,11 @@ TANK6:
 	Mobile:
 		Speed: 128
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 4c0
+		Range: 5c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	Minelayer:
 		Mines: mine1, mine2, mine3, mine4
 	MineImmune:
@@ -419,11 +384,11 @@ TANK5:
 		Speed: 80
 		TurnSpeed: 25
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 6c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	RenderSprites:
 		PlayerPalette: green
 
@@ -450,11 +415,11 @@ TANK10:
 		Speed: 80
 		TurnSpeed: 25
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 6c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Armament:
 		Weapon: VoltageArc
 		LocalOffset: 0,0,213
@@ -491,7 +456,7 @@ TANK7:
 	Mobile:
 		Speed: 120
 	RevealsShroud:
-		Range: 8c0
+		Range: 7c0
 		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
@@ -536,11 +501,11 @@ TANK11:
 	Mobile:
 		Speed: 85
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 6c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	RenderSprites:
 		PlayerPalette: green
 
@@ -575,11 +540,11 @@ TANK12:
 	Mobile:
 		Speed: 71
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 6c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	RenderSprites:
 		PlayerPalette: green
 
@@ -601,10 +566,10 @@ TANK13:
 		Speed: 128
 	RevealsShroud:
 		Range: 5c0
-		MinRange: 4c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	ResourceTransporter:
 		Capacity: 7
 	SpawnActorOnDeath:
@@ -680,10 +645,10 @@ ARTIL2:
 		Locomotor: lighttracked
 	RevealsShroud:
 		Range: 5c0
-		MinRange: 4c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	Armament:
 		Weapon: SmallArtillery
 		LocalOffset: 550,0,800
@@ -727,10 +692,10 @@ ARTIL3:
 		Locomotor: lighttracked
 	RevealsShroud:
 		Range: 6c0
-		MinRange: 4c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Armament:
 		Weapon: DoubleBarrelledArtillery
 		MuzzleSequence: muzzle
@@ -781,10 +746,10 @@ BUILDER:
 		Locomotor: lighttracked
 	RevealsShroud:
 		Range: 6c0
-		MinRange: 4c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	RenderSprites:
 		PlayerPalette: green
 		Image: builder1
@@ -815,10 +780,10 @@ MINER:
 		Speed: 80
 	RevealsShroud:
 		Range: 6c0
-		MinRange: 4c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	RenderSprites:
 		PlayerPalette: green
 	GrantConditionOnTerrain:
@@ -860,11 +825,11 @@ MISSILE_TANK:
 	Mobile:
 		Speed: 80
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 7c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Turreted:
 		TurnSpeed: 40
 		Offset: -250,-50,100
@@ -902,9 +867,12 @@ TANK8:
 	RenderSprites:
 		PlayerPalette: green
 	RevealsShroud:
-		Range: 6c0
+		Range: 7c0
+		MinRange: 3c0
 	CreatesShroud:
-		Range: 8c0
+		Range: 9c0
+	RevealsShroud@Hacked:
+		Range: 3c0
 	RenderShroudCircle:
 
 TANK1:
@@ -928,11 +896,11 @@ TANK1:
 	Mobile:
 		Speed: 140
 	RevealsShroud:
-		Range: 7c0
-		MinRange: 4c0
+		Range: 6c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Demolition:
 		DetonationDelay: 45
 		EnterBehaviour: Dispose
@@ -971,11 +939,11 @@ TANK2:
 	Mobile:
 		Speed: 500
 	RevealsShroud:
-		Range: 7c0
-		MinRange: 4c0
+		Range: 6c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	RenderSprites:
 		PlayerPalette: green
 
@@ -997,10 +965,10 @@ TANKER1:
 		Speed: 128
 	RevealsShroud:
 		Range: 4c0
-		MinRange: 4c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 2c0
 	ResourceTransporter:
 		Capacity: 7
 	SpawnActorOnDeath:


### PR DESCRIPTION
With these changes, whoever sees enemy first, has an advantage. Basically weapon range for units is longer than they see. So if you use scouts like Balloons or Radar Tank, you can suprise your enemy,

Also adjusted vision for some buildings, expecially tech ones, those were huge for some reason.

Also removed `MinRange`, I've got no idea what's the point of that. I know that it was brought from OpenRA RA, but I don't get the idea of units having minimal vision range.