### PR TITLE
Added `DetectCloaked` for actors

### DIFF
--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -139,6 +139,8 @@
 	Demolishable:
 	AnnounceOnSeen:
 		Notification: EnemyUnitsDetected
+	DetectCloaked:
+		Range: 1c0
 
 ^Pod:
 	Inherits: ^Vehicle
@@ -171,6 +173,8 @@
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 2c0
+	DetectCloaked:
+		Range: 1c0
 
 ^Scrap:
 	Interactable:
@@ -542,6 +546,8 @@
 	Capturable:
 		RequiresCondition: !build-incomplete && !beam-incomplete
 	-CommandBarBlacklist:
+	DetectCloaked:
+		Range: 5c0
 
 ^Prop:
 	Inherits: ^Building

--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -119,6 +119,8 @@ SNIPERPOD:
 	WithMuzzleOverlay:
 	RenderSprites:
 		PlayerPalette: green
+	DetectCloaked:
+		Range: 2c0
 
 TECHNICIAN:
 	Inherits: ^Pod

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -257,15 +257,18 @@ RADARTANK:
 		RequiresCondition: !undeployed && real-actor
 		Sequence: extended
 		Name: deployed
-	DetectCloaked:
-		RequiresCondition: !ecmdisabled && deployed
-		Range: 12c0
 	RenderDetectionCircle:
 		TrailCount: 3
 	WithFacingSpriteBody:
 		RequiresCondition: undeployed
 	RenderSprites:
 		PlayerPalette: green
+	DetectCloaked:
+		Range: 8c0
+		RequiresCondition: !ecmdisabled && undeployed
+	DetectCloaked@Deployed:
+		Range: 14c0
+		RequiresCondition: !ecmdisabled && !undeployed
 
 TANK16:
 	Inherits: ^TrackedVehicle
@@ -624,6 +627,8 @@ TANK15:
 		DeflectionRelationships: Neutral, Enemy
 	RenderSprites:
 		PlayerPalette: green
+	DetectCloaked:
+		Range: 2c0
 
 ARTIL2:
 	Inherits: ^TrackedVehicle
@@ -878,6 +883,8 @@ TANK8:
 	RevealsShroud@Hacked:
 		Range: 3c0
 	RenderShroudCircle:
+	DetectCloaked:
+		Range: 2c0
 
 TANK1:
 	Inherits: ^Vehicle


### PR DESCRIPTION
- Base defenses detect clocked actors at 5 tiles range

- Vehicles at range 1 (Hacker and countermeasure tank at 2)

- Radar tank has the same detecting range as far as it reveals shroud.

- Pods at range 1 (Sniper at 2)
