### PR TITLE
Updated plane1,plane2,banshee weapon damage

### DIFF
--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -146,7 +146,7 @@ Plasma:
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
 		Spread: 128
-		Damage: 2400
+		Damage: 3500
 		ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
 		Versus:
 			None: 25

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -69,15 +69,15 @@ ChainGun:
 ChainGun.Shuttle:
 	Inherits: ChainGun
 	ReloadDelay: 3
-	Range: 5c0
-	MinRange: 3c0
+	Range: 6c0
+	MinRange: 2c0
 	Projectile: InstantHit
 		Blockable: false
 	Warhead@Damage: SpreadDamage
 		Spread: 64
 		Damage: 1000
 		Versus:
-			None: 210
+			None: 260
 			Steel: 75
 			Light: 85
 			Heavy: 45

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -172,12 +172,12 @@ ShipMissile:
 		CruiseAltitude: 2c0
 		RangeLimit: 14c410
 	Warhead@Damage: SpreadDamage
-		Damage: 700
+		Damage: 4000
 		Versus:
-			None: 25
-			Wood: 90
-			Light: 90
-			Heavy: 125
+			None: 30
+			Steel: 90
+			Light: 100
+			Heavy: 150
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Damage: 700


### PR DESCRIPTION
- Buffed Banshees' overall damage from 2400 to 3500

- Buffed Speeder's overall damage from 700 to 4000
Modifiers:
* vs None from 25 to 30
* Changed Wood to Steel
* vs Light from 90 to 100
* vs Heavy from 125 to 150

- Increased Gun Ship's weapon range from 5 to 6 tiles and lowered its min range from 3 to 2. 
*  Increased vs None from 210 to 260

None = Pods