### PR TITLE
All ships can detect submarines

### DIFF
--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -780,6 +780,9 @@
 		MovingInterval: 4
 		StartDelay: 4
 		Type: CenterPosition
+	DetectCloaked:
+		CloakTypes: Underwater
+		Range: 2c0
 
 ^Cube:
 	Interactable:

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -42,7 +42,6 @@ BOAT3:
 		Armaments: primary, secondary
 	WithSpriteTurret:
 	DetectCloaked:
-		CloakTypes: Underwater
 		Range: 6c0
 	WithMuzzleOverlay:
 		IgnoreOffset: True
@@ -95,7 +94,6 @@ PATROLBOAT:
 		Armaments: primary, secondary
 	WithSpriteTurret:
 	DetectCloaked:
-		CloakTypes: Underwater
 		Range: 6c0
 	WithMuzzleOverlay:
 
@@ -285,6 +283,8 @@ BOAT4:
 		InitialStanceAI: ReturnFire
 	LeavesTrails:
 		RequiresCondition: cloak-force-disabled
+	DetectCloaked:
+		Range: 1c0
 
 SLCM:
 	Inherits: ^ShootableMissile
@@ -364,3 +364,5 @@ CARRIER:
 		Weapon: DroneLauncher
 	Voiced:
 		VoiceSet: DroneVoice
+	DetectCloaked:
+		Range: 1c0


### PR DESCRIPTION
- By default detection range is 2 tiles.
- Light boat/Patrol boat detection range remains unchanged (6 tiles).
- Carrier and Missile Submarine can detect other submarines at 1 tile range.
