### PR TITLE
Fix Elite Pod LOS

### DIFF
--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -271,6 +271,14 @@ ELITEPOD:
 	WithMoveAnimation:
 	-Explodes@SpawnPilot:
 	-GrantRandomCondition@SpawnPilot:
+	RevealsShroud:
+		Range: 8c0
+		MinRange: 4c0
+		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 4c0
+		Type: GroundPosition
 	Voiced:
 		VoiceSet: ElitePodVoice
 


### PR DESCRIPTION
**NOTE:** I'm not sure if that's the most adequate way to do it and also if the values are balanced enough, but maybe this unit should have a bit less LOS compared to other combat air units.