### PR TITLE
Rebalance Pods and Vehicles

### DIFF
--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -183,11 +183,11 @@
 		CrushClasses: Pods
 		WarnProbability: 15
 	RevealsShroud:
-		Range: 4c0
-		MinRange: 2c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 2c0
+		Range: 8c0
 	DetectCloaked:
 		Range: 1c0
 

--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -103,7 +103,7 @@ SNIPERPOD:
 		Speed: 70
 		Locomotor: pod
 	RevealsShroud:
-		Range: 8c0
+		Range: 10c0
 	Armament@Primary:
 		Weapon: SniperRifle
 		MuzzleSequence: muzzle
@@ -246,7 +246,7 @@ ELITEPOD:
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Buildable:
 		Queue: Scouts
-		Description: Elite airborn pod.\nArmed with heavy machine gun.\n  Strong vs Pod, Light Vehicles and Buildings.
+		Description: Elite airborn pod.\nArmed with heavy machine gun.\n  Strong vs Pod and Light Vehicles\n  Weak vs Buildings.
 		Prerequisites: ~module, techcenter
 	Valued:
 		Cost: 750

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -22,11 +22,11 @@ TANK3:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 25
 		Offset: -125,0,50
@@ -74,11 +74,11 @@ AATANK:
 		Speed: 115
 		Locomotor: wheeled
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 40
 	Armament:
@@ -126,7 +126,7 @@ TRANSPRT:
 		Speed: 110
 		PauseOnCondition: notmobile || ecmdisabled
 	RevealsShroud:
-		Range: 5c0
+		Range: 6c0
 		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
@@ -171,11 +171,11 @@ ARTIL:
 		Speed: 95
 		Locomotor: wheeled
 	RevealsShroud:
-		Range: 5c0
-		MinRange: 3c0
+		Range: 10c0
+		MinRange: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 5c0
 	Armament:
 		Weapon: SmallArtillery
 		MuzzleSequence: muzzle
@@ -293,11 +293,11 @@ TANK16:
 		Speed: 95
 		TurnSpeed: 25
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	AutoTarget:
 		ScanRadius: 8
 		InitialStance: AttackAnything
@@ -325,18 +325,18 @@ TANK6:
 	Mobile:
 		Speed: 128
 	RevealsShroud:
-		Range: 5c0
-		MinRange: 2c0
+		Range: 7c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 2c0
+		Range: 3c0
 	Minelayer:
 		Mines: mine1, mine2, mine3, mine4
 	MineImmune:
 	AmmoPool:
 		Ammo: 5
 	DetectCloaked:
-		Range: 5c0
+		Range: 6c0
 		DetectionTypes: Mine
 	RenderDetectionCircle:
 	Explodes:
@@ -376,11 +376,11 @@ TANK5:
 		Speed: 80
 		TurnSpeed: 25
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 
 TANK10:
 	Inherits: ^TrackedVehicle
@@ -405,11 +405,11 @@ TANK10:
 		Speed: 80
 		TurnSpeed: 25
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	Armament:
 		Weapon: VoltageArc
 		LocalOffset: 0,0,213
@@ -497,11 +497,11 @@ TANK11:
 		TurnSpeed: 25
 		Speed: 90
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	WithMuzzleOverlay:
 
 TANK12:
@@ -575,11 +575,11 @@ ARTIL3:
 		Speed: 85
 		Locomotor: wheeled
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 10c0
+		MinRange: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 5c0
 	Armament:
 		Weapon: DoubleBarrelledArtillery
 		MuzzleSequence: muzzle
@@ -620,11 +620,11 @@ BUILDER:
 		Speed: 100
 		Locomotor: wheeled
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	RenderSprites:
 		Image: builder1
 		FactionImages:
@@ -666,11 +666,11 @@ MINER:
 		TurnSpeed: 30
 		Speed: 80
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	GrantConditionOnTerrain:
 		Condition: validterrain
 		TerrainTypes: Ore
@@ -714,10 +714,10 @@ MISSILE_TANK:
 		Speed: 80
 	RevealsShroud:
 		Range: 7c0
-		MinRange: 3c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 40
 		Offset: -250,-50,100
@@ -752,11 +752,11 @@ TANK8:
 		Speed: 150
 	RevealsShroud:
 		Range: 7c0
-		MinRange: 3c0
+		MinRange: 4c0
 	CreatesShroud:
 		Range: 9c0
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	RenderShroudCircle:
 	DetectCloaked:
 		Range: 2c0
@@ -782,11 +782,11 @@ TANK1:
 	Mobile:
 		Speed: 140
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	Demolition:
 		DetonationDelay: 45
 		EnterBehaviour: Dispose
@@ -824,11 +824,11 @@ TANK2:
 	Mobile:
 		Speed: 500
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 
 TANKER1:
 	Inherits: ^Vehicle
@@ -847,13 +847,13 @@ TANKER1:
 	Mobile:
 		Speed: 128
 	RevealsShroud:
-		Range: 4c0
-		MinRange: 2c0
+		Range: 6c0
+		MinRange: 1c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 2c0
 	ResourceTransporter:
-		Capacity: 8
+		Capacity: 9
 	SpawnActorOnDeath:
 		Actor: goldball
 	-SpawnScrapOnDeath:

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -57,9 +57,9 @@ ChainGun:
 		Spread: 64
 		Damage: 1000
 		Versus:
-			None: 180
+			None: 160
 			Steel: 30
-			Light: 40
+			Light: 35
 			Heavy: 25
 			Concrete: 15
 	Warhead@Incendiary: TreeDamage
@@ -259,8 +259,8 @@ Flamethrower:
 		Spread: 128
 		Damage: 4000
 		Versus:
-			None: 90
-			Steel: 45
+			None: 45
+			Steel: 22
 			Light: 8
 			Heavy: 5
 			Wood: 100
@@ -290,8 +290,8 @@ HeavyMachineGun:
 		Spread: 24
 		Damage: 1000
 		Versus:
-			None: 200
-			Steel: 35
+			None: 100
+			Steel: 20
 			Light: 50
 			Heavy: 25
 			Concrete: 10


### PR DESCRIPTION
The motivation for these changes is to create an unique gameplay for OpenHV and improve balancing. I think I didn't forget anything.

I couldn't test too much with other players so it needs more testing, specially on the high level play.

The list of changes are as follows:

- LOS increased for pods and vehicles
- **Resource Transporter:** increased capacity from 8 to 9 so it gives a bit more resources when delivering to the Storage Facilities
- **Synapol Helicopter's Chaingun:** reduced damage of None from 180 to 160 and Light from 40 to 35
- **Flame Pod's Flamethrower:** reduced damage of None from 90 to 45 and Steel from 45 to 22
- **Elite Pod's Heavy Machinegun:** reduced damage of None from 200 to 100 and Steel from 35 to 20. Now it's an air support pod. The idea is to be used as auxiliary damage unit with other pods and vehicles