### PR TITLE
Re-add Dropship husk with fix

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -394,8 +394,38 @@ DROPSHIP:
 		Position: BottomLeft
 		Margin: 4, 3
 		RequiresSelection: true
+	SpawnActorOnDeath:
+		Actor: DROPSHIP.Husk
+		RequiresCondition: airborne
 	WithAircraftLandingEffect:
 		Image: landing
+
+DROPSHIP.Husk:
+	Inherits: ^PlaneHusk
+	Tooltip:
+		Name: Crashing Transport Dropship
+	Aircraft:
+		TurnSpeed: 24
+		Speed: 86
+	FallsToEarth:
+		Explosion: UnitExplodeLarge
+		Velocity: 43
+	LeavesTrails:
+		Offsets: -853,0,171
+		MovingInterval: 2
+		Image: smoke
+		SpawnAtLastPosition: false
+		Type: CenterPosition
+	RevealsShroud:
+		Range: 4c0
+		MinRange: 2c0
+		Type: GroundPosition
+		RevealGeneratedShroud: false
+	RevealsShroud@Hacked:
+		Range: 2c0
+		Type: GroundPosition
+	RenderSprites:
+		Image: dropship
 
 DRONE:
 	Inherits: ^SpawnedPlane

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -278,6 +278,27 @@
 		EmptyWeapon: PilotSpawn
 		RequiresCondition: spawn-pilot && !dont-spawn-pilot
 
+^PlaneHusk:
+	Inherits@Husk: ^Husk
+	Inherits@Sprite: ^SpriteActor
+	Targetable:
+		TargetTypes: Air, Husk, NoAutoTarget
+	WithShadow:
+		Offset: 43, 128, 0
+		ZOffset: -129
+	Tooltip:
+		GenericName: Destroyed Plane
+	Aircraft:
+	FallsToEarth:
+		Moves: true
+		Velocity: 86
+		Explosion: UnitExplodeSmall
+		MaximumSpinSpeed: 0
+	-MapEditorData:
+	RevealOnDeath:
+		Duration: 60
+		Radius: 4c0
+
 ^SpawnedPlane:
 	Inherits: ^Plane
 	-Selectable:


### PR DESCRIPTION
Readds the Dropship husk (ie crash animation on death), but with fix so that its not triggered when landed ("RequiresCondition: airborne").

I thought its a shame to lose the crashing animation, so I had a look if #660 can't be fixed (while keeping the husk/animation).

Properly fixes https://github.com/OpenHV/OpenHV/issues/660.