### PR TITLE
Copter2 husk+cleanup

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -291,8 +291,39 @@ COPTER2:
 		Position: BottomLeft
 		Margin: 4, 3
 		RequiresSelection: true
+	SpawnActorOnDeath:
+		Actor: COPTER2.Husk
+		RequiresCondition: airborne
 	WithAircraftLandingEffect:
 		Image: landing
+
+COPTER2.Husk:
+	Inherits: ^PlaneHusk
+	Tooltip:
+		Name: Crashing Transport Helicopter
+	Aircraft:
+		TurnSpeed: 24
+		Speed: 86
+	FallsToEarth:
+		Explosion: UnitExplodeLarge
+		Velocity: 43
+		MaximumSpinSpeed: 64
+	LeavesTrails:
+		Offsets: -353,0,171
+		MovingInterval: 2
+		Image: smoke
+		SpawnAtLastPosition: false
+		Type: CenterPosition
+	RevealsShroud:
+		Range: 4c0
+		MinRange: 2c0
+		Type: GroundPosition
+		RevealGeneratedShroud: false
+	RevealsShroud@Hacked:
+		Range: 2c0
+		Type: GroundPosition
+	RenderSprites:
+		Image: copter2
 
 BALLOON:
 	Inherits: ^Helicopter

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -294,6 +294,7 @@ COPTER2:
 	SpawnActorOnDeath:
 		Actor: COPTER2.Husk
 		RequiresCondition: airborne
+	-Explodes@SpawnPilot:
 	WithAircraftLandingEffect:
 		Image: landing
 
@@ -428,6 +429,7 @@ DROPSHIP:
 	SpawnActorOnDeath:
 		Actor: DROPSHIP.Husk
 		RequiresCondition: airborne
+	-Explodes@SpawnPilot:
 	WithAircraftLandingEffect:
 		Image: landing
 


### PR DESCRIPTION
Add a husk for the Transport Helicopter, and remove Pilots spawning on death for both air transports (they look a little weird to me on top of the husks).