### PR TITLE
Allowed Naval Transport to travel ice cliff tiles.

### DIFF
--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -162,6 +162,9 @@
 		TextNotification: Enemy units detected.
 	DetectCloaked:
 		Range: 1c0
+	Passenger:
+		CargoType: Vehicle
+		Weight: 5
 
 ^Pod:
 	Inherits: ^Vehicle
@@ -178,6 +181,7 @@
 		Type: None
 	Passenger:
 		CargoType: Scout
+		Weight: 1
 	-Carryable:
 	-SpawnScrapOnDeath:
 	-Explodes:
@@ -853,6 +857,7 @@
 		MovingInterval: 4
 		StartDelay: 4
 		Type: CenterPosition
+		TerrainTypes: Littoral, Pelagic, Oceanic, Rapids
 	DetectCloaked:
 		DetectionTypes: Underwater
 		Range: 2c0

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -386,9 +386,9 @@ NAVALTRANSPORT:
 	DetectCloaked:
 		Range: 1c0
 	WithLandingCraftAnimation:
-		OpenTerrainTypes: Shore
+		OpenTerrainTypes: Shore, IceCliff
 	Cargo:
-		Types: Scout
+		Types: Scout, Vehicle
 		MaxWeight: 10
 		AfterUnloadDelay: 40
 	WithCargoPipsDecoration:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -148,6 +148,7 @@ TRANSPRT:
 	WithTeleportEnergyOverlay:
 		Image: energyball
 		Sequence: teleport-large
+	-Passenger:
 
 ARTIL:
 	Inherits: ^TrackedVehicle
@@ -599,6 +600,7 @@ ARTIL3:
 	WithMuzzleOverlay:
 	Selectable:
 		DecorationBounds: 1536, 1536
+	-Passenger:
 
 BUILDER:
 	Inherits: ^Vehicle

--- a/mods/hv/rules/world.yaml
+++ b/mods/hv/rules/world.yaml
@@ -144,6 +144,7 @@
 			Oceanic: 100
 			Rapids: 50
 			Shore: 75
+			IceCliff: 75
 	Faction@Yuruki:
 		Name: Yuruki
 		InternalName: yi


### PR DESCRIPTION
Moreover:
- Naval Transport can hold now two vehicles.
- Land Transport and Dual Artillery cannot Naval Transport enter because they are visually too huge.
- Water trail will be only spawned on water tiles (it was also spawned on beach tiles which looked odd).
