### PR TITLE
Make Main Base more durable

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -20,7 +20,7 @@ BASE:
 			TopLeft: -1024, -2048
 			BottomRight: 1024, 1024
 	Health:
-		HP: 210000
+		HP: 250000
 	Armor:
 		Type: Steel
 	RevealsShroud:


### PR DESCRIPTION
Based on experience with bot matches. Main base is to "squishy" and should be more durable as the most important building.