### PR TITLE
Fixed wrong `TargetTypes` for water minelayers.

### DIFF
--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -439,7 +439,7 @@ WATERMINELAYER:
 	Rearmable:
 		RearmActors: harbor, harbor2
 	Targetable:
-		TargetTypes: Ground, Vehicle, Mine
+		TargetTypes: Ground, Water, Ship, Mine
 	AmmoPool:
 		Ammo: 5
 		AmmoCondition: ammo


### PR DESCRIPTION
Submarines weren't able to target water minelayers due to wrong `TargetTypes`, as it was lacking `Ship`.