### PR TITLE
Fix text, remove pod eject for Crater Defense

### DIFF
--- a/mods/hv/maps/crater-defense/crater-defense.lua
+++ b/mods/hv/maps/crater-defense/crater-defense.lua
@@ -1,4 +1,4 @@
-Wave = 1
+CurrentWave = 1
 Breaches = 10
 
 Machine = { "scout1", "scout1", "scout1" }
@@ -30,6 +30,7 @@ WorldLoaded = function()
 	HumanPlayer = Player.GetPlayer("Multi0")
 	EnemyPlayer = Player.GetPlayer("Creeps")
 
+	InitObjectives(HumanPlayer)
 	TowerDefenseObjective = AddPrimaryObjective(HumanPlayer, "not-too-many-enemies-through-trench")
 	UpdateGameStateText()
 
@@ -48,30 +49,29 @@ WorldLoaded = function()
 	SendNextWave()
 end
 
-CachedWaves = -1
+CachedWave = -1
 CachedBreaches = -1
 function UpdateGameStateText()
-	if CachedWaves == Waves and CachedBreaches == Breaches then
+	if CachedWave == CurrentWave and CachedBreaches == Breaches then
 		return
 	end
-	CachedWaves = Waves
+	CachedWave = CurrentWave
 	CachedBreaches = Breaches
 
-	local currentWave = UserInterface.Translate("current-wave", { ["wave"] = Wave, ["waves"] = #Waves })
+	local waveInfo = UserInterface.Translate("current-wave", { ["wave"] = CurrentWave, ["waves"] = #Waves })
 	local tolerableBreaches = UserInterface.Translate("tolerable-breaches", { [ "breaches"] = Breaches })
-	UserInterface.SetMissionText("\n\n\n" .. currentWave .. "\n\n" .. tolerableBreaches)
+	UserInterface.SetMissionText("\n\n\n" .. waveInfo .. "\n\n" .. tolerableBreaches)
 end
 
-
 SendNextWave = function()
-	local wave = Waves[Wave]
+	local wave = Waves[CurrentWave]
 	Trigger.AfterDelay(wave.delay, function()
 		Utils.Do(wave.units, function(units)
 			Attackers = Reinforcements.Reinforce(EnemyPlayer, units, { EntryWaypoint1.Location, ExitWaypoint1.Location })
 		end)
 		UpdateGameStateText()
-		if Wave < #Waves then
-			Wave = Wave + 1
+		if CurrentWave < #Waves then
+			CurrentWave = CurrentWave + 1
 			SendNextWave()
 		else
 			LastWave = true

--- a/mods/hv/maps/crater-defense/map.yaml
+++ b/mods/hv/maps/crater-defense/map.yaml
@@ -16,6 +16,8 @@ Visibility: MissionSelector
 
 Categories: Tower Defense
 
+LockPreview: True
+
 Players:
 	PlayerReference@Neutral:
 		Name: Neutral

--- a/mods/hv/maps/crater-defense/rules.yaml
+++ b/mods/hv/maps/crater-defense/rules.yaml
@@ -19,7 +19,7 @@ Player:
 
 World:
 	LuaScript:
-		Scripts: common|scripts/utils.lua, crater-defense.lua
+		Scripts: common|scripts/utils.lua, hv|scripts/campaign.lua, crater-defense.lua
 	MissionData:
 		Briefing: Commander! The harbors around the Crater Lake are under attack. Use the old railway network to connect your turrets to the energy grid. We are holding the grounds at the exits of the trench, but don't allow too many breaches so our defenses are not overwhelmed.
 	-CubeSpawner:
@@ -111,6 +111,7 @@ BUNKER:
 		Amount: 0
 	Cargo:
 		UnloadTerrainTypes: None
+		EjectOnSell: False
 	ProvidesPrerequisite:
 		Prerequisite: bunker
 
@@ -122,6 +123,7 @@ BUNKER2:
 		Amount: 0
 	Cargo:
 		UnloadTerrainTypes: None
+		EjectOnSell: False
 	ProvidesPrerequisite:
 		Prerequisite: bunker
 


### PR DESCRIPTION
The mission text should update correctly now.
<details><summary>Details:</summary>
The cached wave number was being compared/updated to the Waves table instead of the Wave counter. If a breach happened, the text would only update upon future breaches. That's fixed and Wave is now CurrentWave to add clarity.
</details>

Bunkers no longer eject the garrisoned pod when sold. I figure this was unintended because they're prevented from unloading normally.

Locked the preview image and added InitObjectives to match the other missions.

---

I noticed that reinforcements are stacked on top of each other at the entry point, so it's possible for nearby towers (and Cluster Turrets in particular) to finish waves extra quickly. I steer clear of tower defense games, so I'm unsure if this is normal or how it should be handled if not.