### PR TITLE
Fixed wrong tile types for stone cliffs.

### DIFF
--- a/mods/hv/tileset.yaml
+++ b/mods/hv/tileset.yaml
@@ -7838,17 +7838,17 @@ Templates:
 		Images: bits/terrain/stone.png
 		Frames: 0
 		Size: 1,1
-		Categories: Stone
+		Categories: Stone, Cliff
 		Tiles:
-			0: Stone
+			0: Cliff
 	Template@1048:
 		Id: 1048
 		Images: bits/terrain/stone.png
 		Frames: 1
 		Size: 1,1
-		Categories: Stone
+		Categories: Stone, Cliff
 		Tiles:
-			0: Stone
+			0: Cliff
 	Template@1049:
 		Id: 1049
 		Images: bits/terrain/stone.png
@@ -7865,9 +7865,9 @@ Templates:
 		Images: bits/terrain/stone.png
 		Frames: 6
 		Size: 1,1
-		Categories: Stone
+		Categories: Stone, Cliff
 		Tiles:
-			0: Stone
+			0: Cliff
 	Template@1051:
 		Id: 1051
 		Images: bits/terrain/stone.png
@@ -7883,7 +7883,7 @@ Templates:
 		Size: 1,3
 		Categories: Stone, Cliff
 		Tiles:
-			0: Cliff
+			0: Stone
 			1: Cliff
 			2: Cliff
 	Template@1053:
@@ -7891,17 +7891,17 @@ Templates:
 		Images: bits/terrain/stone.png
 		Frames: 11
 		Size: 1,1
-		Categories: Stone
+		Categories: Stone, Cliff
 		Tiles:
-			0: Stone
+			0: Cliff
 	Template@1054:
 		Id: 1054
 		Images: bits/terrain/stone.png
 		Frames: 12
 		Size: 1,1
-		Categories: Stone
+		Categories: Stone, Cliff
 		Tiles:
-			0: Stone
+			0: Cliff
 	Template@1055:
 		Id: 1055
 		Images: bits/terrain/stone.png


### PR DESCRIPTION
Before:
![image](https://github.com/OpenHV/OpenHV/assets/17529329/1bffb1da-60b4-4417-b187-7086798f6944)

After:
![image](https://github.com/OpenHV/OpenHV/assets/17529329/c59a6f5e-8d53-45ab-9270-70d6fdd84567)
