### PR TITLE
Update status on Fire Watch when fires are clear

### DIFF
--- a/mods/hv/maps/firewatch/firewatch.lua
+++ b/mods/hv/maps/firewatch/firewatch.lua
@@ -85,7 +85,7 @@ end
 CachedburnedPercentage = -1
 UpdateForestStatus = function()
 	local burnedPercentage = (1 - Forest.TreesLeft / Forest.TotalTrees) * 100
-	if (CachedburnedPercentage == burnedPercentage) then
+	if CachedburnedPercentage == burnedPercentage and Forest.TreesBurning > 0 then
 		return
 	end
 	CachedburnedPercentage = burnedPercentage


### PR DESCRIPTION
Fixes an issue where the player can be left with no more fires, but also no official victory because the burn percentage has gone unchanged.