### PR TITLE
Balanced Ramp Buggy and Gatling Bike.

### DIFF
--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -843,7 +843,7 @@ TANK1:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 8000
+		HP: 7500
 	Armor:
 		Type: Light
 	Mobile:
@@ -880,12 +880,12 @@ TANK2:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 10000
+		HP: 9500
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 40
-		Speed: 160
+		TurnSpeed: 100
+		Speed: 170
 	RevealsShroud:
 		Range: 6c0
 		MinRange: 3c0

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -79,7 +79,7 @@ BuggyChainGun:
 		Spread: 24
 		Damage: 1000
 		Versus:
-			None: 175
+			None: 270
 			Steel: 10
 			Light: 30
 			Heavy: 10


### PR DESCRIPTION
- HP decreased by 500 for both vehicles.
- Increased damage against pods.
- Gatling Bike's speed was increased.


@WilliamWeberBerrutti 

Please test it and see if it's any better. The reason why I decreased HP is because I don't want those vehicles to become way too powerful. Pods need to stand a chance too.