### PR TITLE
Adjusted CruiseAltitude for Mothership.

### DIFF
--- a/mods/hv/rules/mothership.yaml
+++ b/mods/hv/rules/mothership.yaml
@@ -7,7 +7,7 @@ MOTHER2C:
 	Aircraft:
 		CanHover: false
 		Speed: 0
-		CruiseAltitude: 2048
+		CruiseAltitude: 4048
 		Repulsable: false
 		-CruisingCondition:
 	-Hovers@Cruising:


### PR DESCRIPTION
I noticed some worm creeps were rendered above the mothership actor. Increasing the cruise altitude should fix it.