### PR TITLE
Rebalance Rocket and Electric Pod attacks, Bomber Pod HP, Airstrike and Pods LOS

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -573,6 +573,7 @@ LANDEDPOD:
 	-WithIdleOverlay@Shadow:
 
 BOMBER1:
+	Inherits: ^SpawnedPlane
 	Inherits@Exists: ^ExistsInWorld
 	Inherits@Sprite: ^SpriteActor
 	Inherits@Handicaps: ^PlayerHandicaps
@@ -588,14 +589,18 @@ BOMBER1:
 		ZOffset: -256
 	Tooltip:
 		Name: Athmospheric Bomber
+	Health:
+		HP: 2000
+	Armor:
+		Type: Light
 	Valued:
 		Cost: 2000
 	UpdatesPlayerStatistics:
 		AddToAssetsValue: false
 	Aircraft:
-		TurnSpeed: 28
-		Speed: 512
-		Repulsable: False
+		TurnSpeed: 360
+		Speed: 450
+		Repulsable: True
 		Voice: Move
 	RejectsOrders:
 	AttackBomber:

--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -14,6 +14,12 @@ SCOUT1:
 		Name: Machine Gun Pod
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
+	RevealsShroud:
+		Range: 6c0
+		MinRange: 3c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 3c0
 	Armament@Primary:
 		Weapon: LightMachineGun
 		MuzzleSequence: muzzle
@@ -40,6 +46,12 @@ SCOUT2:
 		Name: Rocket Pod
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
+	RevealsShroud:
+		Range: 6c0
+		MinRange: 3c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 3c0
 	Armament@Primary:
 		Weapon: LightPodRocket
 		MuzzleSequence: muzzle
@@ -67,6 +79,12 @@ MORTARPOD:
 		Name: Mortar Pod
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
+	RevealsShroud:
+		Range: 7c0
+		MinRange: 3c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 3c0
 	Armament@Primary:
 		Weapon: mortargun
 		MuzzleSequence: muzzle
@@ -100,7 +118,11 @@ SNIPERPOD:
 		Speed: 70
 		Locomotor: pod
 	RevealsShroud:
-		Range: 8c0
+		Range: 10c0
+		MinRange: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 5c0
 	Armament@Primary:
 		Weapon: SniperRifle
 		MuzzleSequence: muzzle
@@ -141,7 +163,11 @@ FLAMEPOD:
 		Locomotor: pod
 		Voice: Move
 	RevealsShroud:
-		Range: 8c0
+		Range: 5c0
+		MinRange: 2c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 2c0
 	Armament@Primary:
 		Weapon: Flamethrower
 		LocalOffset: 200,175,0, 200,-175,0
@@ -168,6 +194,12 @@ TECHNICIAN:
 		Name: Technician Pod
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
+	RevealsShroud:
+		Range: 5c0
+		MinRange: 2c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 2c0
 	CaptureManager:
 	Captures:
 		CaptureTypes: building
@@ -215,6 +247,12 @@ BROKERPOD:
 		Name: Broker pod
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
+	RevealsShroud:
+		Range: 5c0
+		MinRange: 2c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 2c0
 	Health:
 		HP: 17500
 	Mobile:
@@ -304,6 +342,12 @@ BOMBERPOD:
 		HP: 10000
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
+	RevealsShroud:
+		Range: 5c0
+		MinRange: 2c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 2c0
 	-Guard:
 	WithIdleAnimation:
 		Interval: 25, 25
@@ -348,6 +392,12 @@ ELECTRICPOD:
 		VoiceSet: ElectricPodVoice
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
+	RevealsShroud:
+		Range: 6c0
+		MinRange: 3c0
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 3c0
 	Armament@Primary:
 		Weapon: PodVoltageArc
 		LocalOffset: 350,0,0

--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -301,7 +301,7 @@ BOMBERPOD:
 	Tooltip:
 		Name: Bomber Pod
 	Health:
-		HP: 25000
+		HP: 10000
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	-Guard:

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -191,12 +191,12 @@ PodVoltageArc:
 		Radius: 2
 	Warhead@Damage: SpreadDamage
 		Spread: 128
-		Damage: 2300
+		Damage: 2500
 		Versus:
-			None: 60
-			Steel: 76
-			Light: 40
-			Heavy: 100
+			None: 65
+			Steel: 75
+			Light: 70
+			Heavy: 110
 			Concrete: 50
 		ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
 	Warhead@Incendiary: TreeDamage

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -105,7 +105,7 @@ LightPodRocket:
 	Inherits: ^AntiGroundMissile
 	ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
 	Range: 5c512
-	ReloadDelay: 60
+	ReloadDelay: 45
 	Projectile: Missile
 		Speed: 341
 		Arm: 2
@@ -118,12 +118,12 @@ LightPodRocket:
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
 		Spread: 128
-		Damage: 2500
+		Damage: 1875
 		Versus:
-			None: 60
-			Steel: 76
-			Light: 60
-			Heavy: 100
+			None: 65
+			Steel: 75
+			Light: 70
+			Heavy: 110
 			Concrete: 50
 
 RapidPodRocket:

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -4,7 +4,6 @@
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
 	ReloadDelay: 50
 	Range: 5c0
-	MinRange: 0c512
 	Report: rocketlaunch01.wav
 	Projectile: Missile
 		Speed: 213
@@ -112,7 +111,7 @@ LightPodRocket:
 		Inaccuracy: 0
 		Image: bullet7
 		Shadow: true
-		HorizontalRateOfTurn: 60
+		HorizontalRateOfTurn: 100
 		TrailImage: small_smoke
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -8,7 +8,7 @@
 	Report: rocketlaunch01.wav
 	Projectile: Missile
 		Speed: 213
-		Arm: 2
+		Arm: 0
 		Blockable: false
 		Image: bullet6
 		Shadow: true
@@ -107,8 +107,7 @@ LightPodRocket:
 	Range: 5c512
 	ReloadDelay: 45
 	Projectile: Missile
-		Speed: 341
-		Arm: 2
+		Speed: 350
 		Blockable: false
 		Inaccuracy: 0
 		Image: bullet7
@@ -224,7 +223,6 @@ Patriot:
 	Report: rocketlaunch03.wav
 	ValidTargets: Air
 	Projectile: Missile
-		Arm: 1
 		VerticalRateOfTurn: 140
 		Speed: 600
 		MinimumLaunchSpeed: 75
@@ -263,9 +261,8 @@ TowerMissile:
 	Report: rocketlaunch03.wav
 	ValidTargets: Air
 	Projectile: Missile
-		Arm: 1
 		VerticalRateOfTurn: 140
-		Speed: 350
+		Speed: 600
 		MinimumLaunchSpeed: 75
 		MaximumLaunchSpeed: 96
 		Blockable: false

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -107,7 +107,7 @@ LightPodRocket:
 	ReloadDelay: 45
 	Projectile: Missile
 		Image: bullet7
-		VerticalRateOfTurn: 140
+		VerticalRateOfTurn: 40
 		Speed: 600
 		MinimumLaunchSpeed: 75
 		MaximumLaunchSpeed: 96

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -106,6 +106,7 @@ LightPodRocket:
 	Range: 5c512
 	ReloadDelay: 45
 	Projectile: Missile
+		Image: bullet7
 		VerticalRateOfTurn: 140
 		Speed: 600
 		MinimumLaunchSpeed: 75
@@ -117,7 +118,7 @@ LightPodRocket:
 		MinimumLaunchAngle: 128
 		MaximumLaunchAngle: 192
 		AllowSnapping: true
-
+		TrailImage: small_smoke
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
 		Spread: 128

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -118,6 +118,7 @@ LightPodRocket:
 		MinimumLaunchAngle: 128
 		MaximumLaunchAngle: 192
 		AllowSnapping: true
+		CloseEnough: 600
 		TrailImage: small_smoke
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
@@ -240,6 +241,7 @@ Patriot:
 		MaximumLaunchAngle: 192
 		CruiseAltitude: 2c0
 		AllowSnapping: true
+		CloseEnough: 600
 	Warhead@Damage: SpreadDamage
 		Spread: 128
 		Damage: 2000
@@ -279,6 +281,7 @@ TowerMissile:
 		MaximumLaunchAngle: 192
 		CruiseAltitude: 2c0
 		AllowSnapping: true
+		CloseEnough: 600
 	Warhead@Damage: SpreadDamage
 		Spread: 128
 		Damage: 4000

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -121,7 +121,7 @@ LightPodRocket:
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
 		Spread: 128
-		Damage: 1875
+		Damage: 2500
 		Versus:
 			None: 65
 			Steel: 75

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -13,7 +13,7 @@
 		Shadow: true
 		HorizontalRateOfTurn: 20
 		TrailImage: smoke
-		CruiseAltitude: 2c0
+		RangeLimit: -1
 	Warhead@Smudge: LeaveSmudge
 		SmudgeType: Crater
 		Chance: 25
@@ -106,13 +106,18 @@ LightPodRocket:
 	Range: 5c512
 	ReloadDelay: 45
 	Projectile: Missile
-		Speed: 350
+		VerticalRateOfTurn: 140
+		Speed: 600
+		MinimumLaunchSpeed: 75
+		MaximumLaunchSpeed: 96
 		Blockable: false
-		Inaccuracy: 0
-		Image: bullet7
 		Shadow: true
 		HorizontalRateOfTurn: 100
-		TrailImage: small_smoke
+		Acceleration: 96
+		MinimumLaunchAngle: 128
+		MaximumLaunchAngle: 192
+		AllowSnapping: true
+
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
 		Spread: 128

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -130,6 +130,10 @@ RapidPodRocket:
 	Inherits: LightPodRocket
 	ReloadDelay: 20
 	Range: 8c0
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		Spread: 128
+		Damage: 2500
 
 ShipMissile:
 	Inherits: ^AntiGroundMissile


### PR DESCRIPTION
This PR attempts to fix https://github.com/OpenHV/OpenHV/issues/921, reduces Bomber Pod HP, makes Airstrike planes being targetted and increases pods LOS.