### PR TITLE
Refine bunker damages

### DIFF
--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -91,7 +91,7 @@ MORTARPOD:
 		LocalOffset: 0,0,200
 	Armament@GARRISONED:
 		Name: garrisoned
-		Weapon: mortargun
+		Weapon: BunkerMortarGun
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		PauseOnCondition: ecm-disabled

--- a/mods/hv/weapons/ballistics.yaml
+++ b/mods/hv/weapons/ballistics.yaml
@@ -330,3 +330,9 @@ mortargun:
 		Explosions: small
 		ValidTargets: Ground, Tree
 		ImpactSounds: explosion06.wav
+
+BunkerMortarGun:
+	Inherits: mortargun
+	Range: 9c0
+	ReloadDelay: 25
+	MinRange: 0

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -206,8 +206,8 @@ PodVoltageArc:
 
 RapidPodVoltageArc:
 	Inherits: PodVoltageArc
-	ReloadDelay: 20
 	Range: 8c0
+	ReloadDelay: 30
 
 LightningBolt:
 	ReloadDelay: 60

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -26,16 +26,9 @@ LightMachineGun:
 
 BunkerChaingun:
 	Inherits: LightMachineGun
-	Report: heavymgburst01.wav, heavymgburst02.wav
-	Warhead@Damage: SpreadDamage
-		Spread: 24
-		Damage: 3000
-	Warhead@Incendiary: TreeDamage
-		Spread: 24
-		Damage: 3000
-	ReloadDelay: 15
+	ReloadDelay: 10
+	BurstDelays: 3
 	Range: 8c0
-	Burst: 1
 
 ^AircraftChainGun:
 	Inherits: SmallSplash
@@ -180,9 +173,7 @@ SniperRifle:
 
 BunkerSniperRifle:
 	Inherits: SniperRifle
-	ReloadDelay: 20
-	Range: 11c0
-	Burst: 1
+	ReloadDelay: 25
 
 BoatMachineGun:
 	Inherits: SmallSplash
@@ -303,8 +294,8 @@ Flamethrower:
 
 BunkerFlamethrower:
 	Inherits: Flamethrower
-	ReloadDelay: 40
-	Range: 8c0
+	ReloadDelay: 25
+	Range: 5c0
 
 HeavyMachineGun:
 	Inherits: LightMachineGun

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -275,7 +275,7 @@ Flamethrower:
 		DamageTypes: Fire
 		ValidTargets: Ground, Water, Tree, Lava, Swamp
 		Spread: 128
-		Damage: 4000
+		Damage: 2000
 		Versus:
 			None: 90
 			Steel: 45
@@ -283,7 +283,7 @@ Flamethrower:
 			Heavy: 5
 			Wood: 100
 	Warhead@Incendiary: TreeDamage
-		Damage: 4000
+		Damage: 2000
 		Spread: 128
 		Percentage: 75
 	Warhead@FireEffect: CreateEffect

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -133,12 +133,8 @@ LightPodRocket:
 
 RapidPodRocket:
 	Inherits: LightPodRocket
-	ReloadDelay: 20
+	ReloadDelay: 23
 	Range: 8c0
-	Warhead@Damage: SpreadDamage
-		DamageTypes: Fire
-		Spread: 128
-		Damage: 2500
 
 ShipMissile:
 	Inherits: ^AntiGroundMissile


### PR DESCRIPTION
Idea: Pods inside bunkers will receive a proportional range increase (~50%) (except Sniper Pods maybe since they already have a long range), 2x firerate and no minrange (for Flamer Pods). This PR also nerfs Flamer Pods damage too.