### PR TITLE
Add The `EnemyWatcher` Trait To Recon Units

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -216,6 +216,7 @@ SAUCER:
 		IsDecoration: true
 		Sequence: shadow-overlay
 		Palette: shadow
+	EnemyWatcher:
 
 BANSHEE:
 	Inherits: ^Helicopter
@@ -402,6 +403,7 @@ BALLOON:
 		IsDecoration: true
 		Sequence: shadow-overlay
 		Palette: shadow
+	EnemyWatcher:
 
 DROPSHIP:
 	Inherits: ^Helicopter

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -258,6 +258,7 @@ RADARTANK:
 		Range: 14c0
 		RequiresCondition: !ecm-disabled && !undeployed
 		DetectionTypes: Cloak, Underwater
+  	EnemyWatcher:
 
 TANK16:
 	Inherits: ^TrackedVehicle


### PR DESCRIPTION
This PR fix the issue described in #924, by adding the `EnemyWatcher` attribute to the Recon Tank, that allows him to send messages when it detects enemy or neutral units. I also gave it to the Synapol Scout Balloon and the Yuruki Scout Saucer.