### PR TITLE
Enhance Bot Support Power Decisions

### DIFF
--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -219,7 +219,7 @@ Player:
 				Consideration@1:
 					Against: Enemy
 					Types: Structure
-					Attractiveness: 1.5
+					Attractiveness: 2
 					TargetMetric: None
 					CheckRadius: 8c0
 				Consideration@2:

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -219,7 +219,7 @@ Player:
 				Consideration@1:
 					Against: Enemy
 					Types: Structure
-					Attractiveness: 1
+					Attractiveness: 1.5
 					TargetMetric: None
 					CheckRadius: 8c0
 				Consideration@2:
@@ -228,24 +228,42 @@ Player:
 					Attractiveness: -5
 					TargetMetric: None
 					CheckRadius: 8c0
+				Consideration@3:
+					Against: Ally
+					Types: Air, Ground, Water
+					Attractiveness: 1
+					TargetMetric: None
+					CheckRadius: 8c0
 			AirStrike:
 				OrderName: FlushBombers
-				MinimumAttractiveness: 1
+				MinimumAttractiveness: 5
 				Consideration@1:
 					Against: Enemy
 					Types: Structure
+					Attractiveness: 2
+					TargetMetric: None
+					CheckRadius: 5c0
+				Consideration@2:
+					Against: Ally
+					Types: Air, Ground, Unit
 					Attractiveness: 1
 					TargetMetric: None
 					CheckRadius: 5c0
 			Howitzer:
 				OrderName: FireMission
-				MinimumAttractiveness: 1
+				MinimumAttractiveness: 5
 				Consideration@1:
 					Against: Enemy
 					Types: Structure
-					Attractiveness: 1
+					Attractiveness: 2
 					TargetMetric: None
 					CheckRadius: 5c0
+				Consideration@2:
+					Against: Enemy
+					Types: Ground
+					Attractiveness: 1
+					TargetMetric: None
+					CheckRadius: 3c0
 			Railgun:
 				OrderName: Blastem
 				MinimumAttractiveness: 1000

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -229,8 +229,8 @@ Player:
 					TargetMetric: None
 					CheckRadius: 8c0
 				Consideration@3:
-					Against: Ally
-					Types: Air, Ground, Water
+					Against: Enemy
+					Types: Air, Ground
 					Attractiveness: 1
 					TargetMetric: None
 					CheckRadius: 8c0
@@ -244,8 +244,8 @@ Player:
 					TargetMetric: None
 					CheckRadius: 5c0
 				Consideration@2:
-					Against: Ally
-					Types: Air, Ground, Unit
+					Against: Enemy
+					Types: Ground
 					Attractiveness: 1
 					TargetMetric: None
 					CheckRadius: 5c0


### PR DESCRIPTION
This PR tries to enhance a bit the bots' support power decisions:
- bots will now drop pods against enemy air and ground units, instead of just structures
- bots will now flush bombers against enemy ground units, instead of just structures
- bots will now launch howitzer attacks against enemy ground units, instead of just structures