### PR TITLE
Make Dual Artillery Obtainable

### DIFF
--- a/mods/hv/rules/trade.yaml
+++ b/mods/hv/rules/trade.yaml
@@ -96,6 +96,19 @@ ARTIL.TRADE:
 	UpdatesPlayerStatistics:
 		OverrideActor: artil
 
+ARTIL3.TRADE:
+	Inherits: ARTIL3
+	Buildable:
+		Queue: Trade
+		Prerequisites: tradplat, techcenter
+	VariedCostMultiplier:
+		Queues: Trade
+	-MapEditorData:
+	RenderSprites:
+		Image: artil3
+	UpdatesPlayerStatistics:
+		OverrideActor: artil3
+
 RADARTANK.TRADE:
 	Inherits: RADARTANK
 	Buildable:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -597,6 +597,7 @@ ARTIL3:
 		TurnSpeed: 8
 		Speed: 85
 		Locomotor: wheeled
+		CanMoveBackward: true
 	RevealsShroud:
 		Range: 6c0
 		MinRange: 3c0

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -579,7 +579,7 @@ ARTIL3:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1750
+		Cost: 1850
 	Tooltip:
 		Name: actor-artil3.name
 	UpdatesPlayerStatistics:


### PR DESCRIPTION
The Dual Artillery vehicle can now be built through the tradplat. Its price also has been increased.