### PR TITLE
Fix MakeFile Install Data

### DIFF
--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -86,5 +86,6 @@ install_data() (
 	cp -r "${SRC_PATH}/mods/common" "${DEST_PATH}/mods/"
 
 	echo "Installing Hard Vacuum mod files to ${DEST_PATH}"
+ 	rm -r "${DEST_PATH}/mods/hv/"*
 	cp -r "${SRC_PATH}/../mods/hv" "${DEST_PATH}/mods/"
 )

--- a/packaging/functions.sh
+++ b/packaging/functions.sh
@@ -86,6 +86,8 @@ install_data() (
 	cp -r "${SRC_PATH}/mods/common" "${DEST_PATH}/mods/"
 
 	echo "Installing Hard Vacuum mod files to ${DEST_PATH}"
- 	rm -r "${DEST_PATH}/mods/hv/"*
+ 	if [ -d "${DEST_PATH}/mods/hv/" ]; then
+ 		rm -r "${DEST_PATH}/mods/hv/"*
+	fi
 	cp -r "${SRC_PATH}/../mods/hv" "${DEST_PATH}/mods/"
 )


### PR DESCRIPTION
This RP adds a new line to the function that install the mod's data when running `sudo make install`, so it deletes the content of the directory before installing the mod. Before this, if you, for example, renamed a file in the mod data, and then run make install, the mod installation folder will contain the renamed file, and the original, which's a problem. This PR fixes this problem.