### PR TITLE
Decreased interval for idle animations of Ore Smelter/Purifier.

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -1066,6 +1066,7 @@ ORESMELT:
 		Amount: 10
 		RequiresCondition: !build-incomplete && !disabled
 	WithIdleAnimation:
+		Interval: 40
 		RequiresCondition: !build-incomplete && !disabled
 
 OREPURIFIER:
@@ -1081,6 +1082,8 @@ OREPURIFIER:
 	Encyclopedia:
 		Description: actor-orepurifier.encyclopedia
 	-WithIdleOverlay@Shadow:
+	WithIdleAnimation:
+		Interval: 35
 
 BUNKER:
 	Inherits: ^DefenseBuilding

--- a/mods/hv/sequences/buildings.yaml
+++ b/mods/hv/sequences/buildings.yaml
@@ -2252,11 +2252,9 @@ oresmelt:
 		Offset: 0, -2
 	idle:
 		Filename: bits/oresmelt.png
-		Start: 1
 		Length: 1
 	active:
 		Filename: bits/oresmelt.png
-		Start: 1
 		Length: 10
 		Tick: 140
 	damaged-idle:


### PR DESCRIPTION
Due to an oversight it took forever (default value 750) to trigger idle animations for those buildings.
