### PR TITLE
Add the InstantExplode projectile from AS.

### DIFF
--- a/OpenRA.Mods.HV/Projectiles/InstantExplode.cs
+++ b/OpenRA.Mods.HV/Projectiles/InstantExplode.cs
@@ -1,0 +1,54 @@
+#region Copyright & License Information
+/*
+ * Copyright 2019-2023 The OpenHV Developers (see CREDITS)
+ * This file is part of OpenHV, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.GameRules;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.HV.Projectiles
+{
+	[Desc("Imminently explode the weapon directly at the firing position.",
+		"Written with cases where the actor would attack everything around itself in an aura pattern,",
+		"but without self-destructing.")]
+	public class InstantExplodeInfo : IProjectileInfo
+	{
+		public IProjectile Create(ProjectileArgs args) { return new InstantExplode(args); }
+	}
+
+	sealed class InstantExplode : IProjectile
+	{
+		readonly ProjectileArgs args;
+
+		public InstantExplode(ProjectileArgs args)
+		{
+			this.args = args;
+		}
+
+		public void Tick(World world)
+		{
+			world.AddFrameEndTask(w => w.Remove(this));
+
+			var warheadArgs = new WarheadArgs(args)
+			{
+				ImpactOrientation = new WRot(WAngle.Zero, WAngle.Zero, args.CurrentMuzzleFacing()),
+				ImpactPosition = args.Source,
+			};
+
+			args.Weapon.Impact(Target.FromPos(args.Source), warheadArgs);
+		}
+
+		public IEnumerable<IRenderable> Render(WorldRenderer wr)
+		{
+			yield break;
+		}
+	}
+}


### PR DESCRIPTION
In response to the discussion from https://discord.com/channels/840983316395720715/840984330582360124/1253612981602877450

Back in AS, besides using this to simulate multitargeting as explained, I also used this to allow the YR Chaos Drone to attack-move and autotarget.