### PR TITLE
Balance Mothership

### DIFF
--- a/mods/hv/languages/rules/en.ftl
+++ b/mods/hv/languages/rules/en.ftl
@@ -804,6 +804,7 @@ actor-cvit =
 actor-mothership =
    .name = Mothership
    .description = Launches aerial autonomous attack vessels.
+      Only one can be built.
       Strong vs Everything
 
 actor-mothership-husk =

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -285,7 +285,7 @@ CHOPPER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 30000
+		HP: 45000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -419,7 +419,7 @@ DROPSHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 30000
+		HP: 45000
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -547,7 +547,7 @@ DRONE2:
 	Tooltip:
 		Name: actor-drone2.name
 	Health:
-		HP: 5000
+		HP: 7500
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -569,13 +569,14 @@ DRONE2:
 		VTOL: true
 		Repulsable: false
 	AttackAircraft:
-		FacingTolerance: 92
+		FacingTolerance: 256
 		Voice: Attack
 	AmmoPool:
-		Ammo: 50
+		Ammo: 250
+		ReloadCount: 15
 		AmmoCondition: ammo
 	CarrierChild:
-		LandingDistance: 8c0
+		LandingDistance: 16c0
 	Rearmable:
 		RearmActors: mothership
 	WithMuzzleOverlay:
@@ -682,7 +683,7 @@ AIRLIFTER:
 MOTHERSHIP:
 	Inherits: ^Helicopter
 	Inherits@Smoke: ^SmokeEmitter
-	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
 		Cost: 6000
 	Tooltip:
@@ -690,12 +691,13 @@ MOTHERSHIP:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 100
-		Prerequisites: ~starport.sc, techcenter, ~disabled
+		BuildLimit: 1
+		Prerequisites: radar, trader, techcenter, ~starport.sc
 		Description: actor-mothership.description
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 100000
+		HP: 250000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -729,23 +731,29 @@ MOTHERSHIP:
 	Exit:
 		SpawnOffset: 0,0,0
 		Facing: 0
+	AutoTarget:
+		InitialStance: Defend
+		InitialStanceAI: AttackAnything
+	Exit:
+		SpawnOffset: 0,0,0
+		Facing: 0
 	Turreted@DroneLauncher:
 		Turret: primary
 		Offset: 0,0,0
-		TurnSpeed: 240
+		TurnSpeed: 120
 	Turreted@LaserTurret:
 		Turret: secondary
 		Offset: -200,0,-100
-		TurnSpeed: 120
+		TurnSpeed: 240
 	AttackTurreted:
 	Armament@DroneLauncher:
 		Name: primary
 		Weapon: Drone2Launcher
-		LocalOffset: 0,0,-100
+		LocalOffset: 0,0,0
 	Armament@LaserTurret:
 		Name: secondary
 		Weapon: MothershipLaser
-		LocalOffset: 500,300,-100, 500,-300,-100
+		LocalOffset: 300,300,-100, 300,-300,-100, -300,300,-100, -300,-300,-100
 	Voiced:
 		VoiceSet: MotherShipVoice
 	-GrantRandomCondition@SpawnPilot:

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -139,6 +139,7 @@ Player:
 			mineship: 1
 			mineship2: 1
 			battleship: 1
+			mothership: 1
 		UnitLimits:
 			miner: 1
 			builder: 1

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -676,7 +676,7 @@ STARPORT:
 		RequiresCondition: !being-captured && !build-incomplete
 		SpawnOffset: 0,-256,0
 		ExitCell: 0,0
-		Facing: 896
+		Facing: 512
 	RallyPoint:
 		CirclesSequence:
 		IsPlayerPalette: true

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -233,13 +233,13 @@ LightningBolt:
 		ZOffset: 2048
 	Warhead@Damage: SpreadDamage
 		Spread: 128
-		Damage: 4000
+		Damage: 3000
 		ValidTargets: Air
 		Versus:
 			None: 30
 			Wood: 90
 			Light: 90
-			Heavy: 115
+			Heavy: 300
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
@@ -268,7 +268,7 @@ LightningBoltLight:
 			None: 30
 			Wood: 90
 			Light: 90
-			Heavy: 115
+			Heavy: 300
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
@@ -478,10 +478,10 @@ MothershipLaser:
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
 	ReloadDelay: 5
 	Range: 8c0
-	MinRange: 1c0
+	MinRange: 0c0
 	Report: laserblaster_newlocknew.ogg
 	Projectile: Bullet
-		Speed: 550
+		Speed: 825
 		Blockable: false
 		Inaccuracy: 0
 		Image:
@@ -495,16 +495,17 @@ MothershipLaser:
 		Chance: 25
 		InvalidTargets: Vehicle, Structure
 	Warhead@Damage: SpreadDamage
-		Damage: 1000
+		Spread: 128
+		Damage: 2500
 		Versus:
-			None: 65
-			Steel: 75
-			Light: 70
-			Heavy: 110
-			Concrete: 50
+			None: 300
+			Steel: 125
+			Light: 200
+			Heavy: 250
+			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
-		Damage: 1750
+		Damage: 2500
 	Warhead@Effect: CreateEffect
 		Explosions: small
 		ImpactSounds: explosion06.ogg

--- a/mods/hv/weapons/fake.yaml
+++ b/mods/hv/weapons/fake.yaml
@@ -8,13 +8,13 @@ DroneLauncher:
 		ValidTargets: Ground, Water
 
 Drone2Launcher:
-	ReloadDelay: 30
+	ReloadDelay: 15
 	Range: 12c0
 	MinRange: 1c0
-	ValidTargets: Water, Air, Ground, Tree, Lava, Swamp
+	ValidTargets: Air
 	Projectile: InstantHit
 	Warhead@Damage: TargetDamage
-		ValidTargets: Water, Air, Ground, Tree, Lava, Swamp
+		ValidTargets: Air
 
 MissileLauncher:
 	ReloadDelay: 150

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -154,7 +154,7 @@ HelicopterChainGunAir:
 		Damage: 250
 		Versus:
 			Light: 167
-			Heavy: 23
+			Heavy: 115
 
 AircraftChainGunGround:
 	Inherits: ^AircraftChainGun
@@ -184,7 +184,7 @@ AircraftChainGunAir:
 		Damage: 375
 		Versus:
 			Light: 207
-			Heavy: 37
+			Heavy: 185
 
 ShellCasing:
 	Inherits: SmallSplash
@@ -262,12 +262,12 @@ BoatMachineGunAir:
 		Inaccuracy: 0c512
 	Warhead@Damage: SpreadDamage
 		Spread: 126
-		Damage: 150
+		Damage: 190
 		ValidTargets: Air
 		Versus:
 			None: 30
 			Light: 90
-			Heavy: 180
+			Heavy: 360
 	Warhead@GroundEffect: CreateEffect
 		Explosions: small
 		ValidTargets: Air
@@ -340,15 +340,15 @@ DronePulseGun:
 	Inherits: SmallSplash
 	Inherits: Ricochet
 	Inherits: ^BlueTracers
-	ValidTargets: Water, Air, Ground, Tree, Lava, Swamp
+	ValidTargets: Air
 	Report: pulsegun_silverillusionist.ogg
 	Projectile: InstantHitWithTracers
 		Inaccuracy: 0c256
 		Blockable: true
 	Warhead@Damage: SpreadDamage
-		ValidTargets: Water, Air, Ground, Tree, Lava, Swamp
+		ValidTargets: Air
 		Spread: 24
-		Damage: 5000
+		Damage: 2500
 		Versus:
 			None: 125
 			Steel: 15
@@ -357,7 +357,8 @@ DronePulseGun:
 			Concrete: 10
 	Warhead@Incendiary: TreeDamage
 		Spread: 24
-		Damage: 1000
+		Damage: 2500
 	ReloadDelay: 10
 	Range: 6c0
+	MinRange: 0c0
 	Burst: 10

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -223,7 +223,7 @@ BoatMissileAntiAir:
 		Versus:
 			None: 30
 			Light: 90
-			Heavy: 180
+			Heavy: 360
 	Warhead@Effect: CreateEffect
 		Explosions: small
 		ImpactSounds: explosion06.ogg
@@ -315,13 +315,13 @@ TowerMissile:
 		CloseEnough: 600
 	Warhead@Damage: SpreadDamage
 		Spread: 128
-		Damage: 4000
+		Damage: 3000
 		ValidTargets: Air
 		Versus:
 			None: 30
 			Wood: 90
 			Light: 90
-			Heavy: 115
+			Heavy: 300
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Spread: 128


### PR DESCRIPTION
This PR also rebalances many AA attacks against Heavy armored units, increases air transports HP and changes initial facings for all starport units.

For the interceptors to return, https://github.com/OpenHV/OpenHV/issues/1006 must be fixed.

**NOTE:** This PR ideally should be merged together with [Balance Battleship](https://github.com/OpenHV/OpenHV/pull/1096).