### PR TITLE
Allow WithIdleOverlayOnGround to support facings.

### DIFF
--- a/OpenRA.Mods.HV/Traits/Render/WithIdleOverlayOnGround.cs
+++ b/OpenRA.Mods.HV/Traits/Render/WithIdleOverlayOnGround.cs
@@ -66,9 +66,10 @@ namespace OpenRA.Mods.HV.Traits.Render
 		{
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
+			var facing = self.TraitOrDefault<IFacing>();
 
 			var image = info.Image ?? rs.GetImage(self);
-			overlay = new Animation(self.World, image, () => IsTraitPaused)
+			overlay = new Animation(self.World, image, facing == null ? () => WAngle.Zero : (body == null ? () => facing.Facing : () => body.QuantizeFacing(facing.Facing)), () => IsTraitPaused)
 			{
 				IsDecoration = info.IsDecoration
 			};


### PR DESCRIPTION
I'm not sure if this got lost during a refactor or was never there, suddenly. I think it's the former.