### PR TITLE
Increase AutoTarget scanning intervals.

### DIFF
--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -764,6 +764,8 @@
 ^AutoTargetGround:
 	AutoTarget:
 		AttackAnythingCondition: stance-attackanything
+		MinimumScanTimeInterval: 5
+		MaximumScanTimeInterval: 15
 	AutoTargetPriority@Default:
 		RequiresCondition: !stance-attackanything
 		ValidTargets: Vehicle, Defense, Ship, Mine
@@ -784,6 +786,8 @@
 
 ^AutoTargetAir:
 	AutoTarget:
+		MinimumScanTimeInterval: 5
+		MaximumScanTimeInterval: 15
 	AutoTargetPriority@Default:
 		ValidTargets: Air
 		InvalidTargets: NoAutoTarget
@@ -791,6 +795,8 @@
 ^AutoTargetAll:
 	AutoTarget:
 		AttackAnythingCondition: stance-attackanything
+		MinimumScanTimeInterval: 5
+		MaximumScanTimeInterval: 15
 	AutoTargetPriority@Default:
 		RequiresCondition: !stance-attackanything
 		ValidTargets: Vehicle, Air, Ship, Mine, Defense

--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -229,6 +229,8 @@ TECHNICIAN:
 	AutoTarget:
 		ScanRadius: 8
 		InitialStance: AttackAnything
+		MinimumScanTimeInterval: 5
+		MaximumScanTimeInterval: 15
 	AutoTargetPriority@Default:
 		ValidTargets: DamagedPod
 	Armament:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -589,6 +589,8 @@ ECMTANK:
 		Voice: Attack
 		FacingTolerance: 0
 	AutoTarget:
+		MinimumScanTimeInterval: 5
+		MaximumScanTimeInterval: 15
 	AutoTargetPriority@Default:
 		ValidTargets: Jammable
 	-Targetable@ECM:
@@ -879,6 +881,8 @@ HACKERTANK:
 		Weapon: HackBack
 	AttackFrontal:
 	AutoTarget:
+		MinimumScanTimeInterval: 5
+		MaximumScanTimeInterval: 15
 	AutoTargetPriority@Default:
 		ValidTargets: Vulnerability
 		RequiresCondition: !controlling


### PR DESCRIPTION
Should decrease CPU pressure at the cost of lost unit reaction. Might need further tweaking longterm.