### PR TITLE
Change all transport units

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -471,7 +471,7 @@ CHOPPER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 49500 # 52500  # 49875
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -483,8 +483,8 @@ CHOPPER:
 		Range: 4c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 20
-		Speed: 135
+		TurnSpeed: 18
+		Speed: 122
 		AltitudeVelocity: 0c58
 		LandableTerrainTypes: Clear, Ore, Crater, Road, Grass, Grass Pit, Mountain, Snow, Red Snow, Sand, Black Sand, Stone, Tech, Rail, Blocked, Dirt
 	Voiced:
@@ -498,17 +498,11 @@ CHOPPER:
 	Selectable:
 		DecorationBounds: 2048, 1843
 	Cargo:
-		Types: Pod
+		Types: Pod, Vehicle
 		MaxWeight: 8
-		AfterUnloadDelay: 40
+		AfterUnloadDelay: 0
 		RequiresCondition: !carrying
 		LoadedCondition: loaded
-	Carryall:
-		BeforeLoadDelay: 10
-		BeforeUnloadDelay: 10
-		LocalOffset: 0,0,-200
-		CarryCondition: carrying
-		RequiresCondition: !loaded
 	WithCargoPipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3
@@ -613,7 +607,7 @@ DROPSHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 40500 # 47500  # 45125
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -625,8 +619,8 @@ DROPSHIP:
 		Range: 4c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 20
-		Speed: 135
+		TurnSpeed: 22
+		Speed: 149
 		AltitudeVelocity: 0c58
 		InitialFacing: 512
 		LandableTerrainTypes: Clear, Ore, Crater, Road, Grass, Grass Pit, Mountain, Snow, Red Snow, Sand, Black Sand, Stone, Tech, Rail, Blocked, Dirt
@@ -641,9 +635,9 @@ DROPSHIP:
 	Selectable:
 		DecorationBounds: 2048, 1848
 	Cargo:
-		Types: Pod
+		Types: Pod, Vehicle
 		MaxWeight: 8
-		AfterUnloadDelay: 40
+		AfterUnloadDelay: 0
 		UnloadVoice: Unload
 		RequiresCondition: !carrying
 		LoadedCondition: loaded

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -178,7 +178,7 @@
 		Range: 1c0
 	Passenger:
 		CargoType: Vehicle
-		Weight: 5
+		Weight: 4
 
 ^Pod:
 	Inherits: ^Vehicle

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -467,7 +467,7 @@ FERRY:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor
+		Prerequisites: ~harbor.yi
 		BuildPaletteOrder: 20
 		Description: actor-ferry.description
 	Encyclopedia:
@@ -477,13 +477,13 @@ FERRY:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 50000
+		HP: 49500  # 52250  # 47500
 	Armor:
 		Type: Heavy
 	Mobile:
 		Locomotor: ferry
-		Speed: 80
-		TurnSpeed: 50
+		Speed: 88
+		TurnSpeed: 55
 	RevealsShroud:
 		Range: 6c0
 		MinRange: 4c0
@@ -500,6 +500,16 @@ FERRY:
 		Position: BottomLeft
 		Margin: 1, -1
 		RequiresSelection: true
+
+FERRY2:
+	Inherits: FERRY
+	Buildable:
+		Prerequisites: ~harbor.sc
+	Health:
+		HP: 60500  # 57750  # 52500
+	Mobile:
+		Speed: 72
+		TurnSpeed: 45
 
 MINESHIP:
 	Inherits: ^Ship

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -133,7 +133,7 @@ APC:
 		Name: actor-apc.name
 	Buildable:
 		Queue: Tank
-		Prerequisites: factory, module
+		Prerequisites: ~factory.yi, module
 		BuildPaletteOrder: 40
 		Description: actor-apc.description
 	Encyclopedia:
@@ -143,11 +143,12 @@ APC:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 25000
+		HP: 22500 # 23750
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 110
+		TurnSpeed: 22 # 21
+		Speed: 121 # 115
 		PauseOnCondition: loading || jammed
 	RevealsShroud:
 		Range: 6c0
@@ -182,6 +183,16 @@ APC:
 		Image: energyball
 		Sequence: teleport-large
 	-Passenger:
+
+APC2:
+	Inherits: APC
+	Buildable:
+		Prerequisites: ~factory.sc, module
+	Health:
+		HP: 27500 # 26250
+	Mobile:
+		TurnSpeed: 18
+		Speed: 99
 
 ARTILLERY:
 	Inherits: ^TrackedVehicle

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -1025,6 +1025,9 @@ BUGGY:
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 3c0
+	Passenger:
+		CargoType: Vehicle
+		Weight: 2
 
 BIKE:
 	Inherits: ^Vehicle
@@ -1069,6 +1072,9 @@ BIKE:
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
+	Passenger:
+		CargoType: Vehicle
+		Weight: 2
 
 TANKER1:
 	Inherits: ^Vehicle

--- a/mods/hv/sequences/ships.yaml
+++ b/mods/hv/sequences/ships.yaml
@@ -144,7 +144,29 @@ watertrail:
 		Tick: 80
 		ZOffset: -2048
 
+# TODO: Change one of them both below later
 ferry:
+	idle:
+		Filename: bits/ferry.png
+	open:
+		Filename: bits/ferry.png
+		Length: 4
+		Tick: 150
+	close:
+		Filename: bits/ferry.png
+		Frames: 3, 2, 1, 0
+		Length: 4
+		Tick: 150
+	unload:
+		Filename: bits/ferry.png
+		Start: 3
+		ZOffset: -511
+	icon:
+		Filename: bits/units-icons.png
+		Start: 56
+		Offset: 2, 0
+
+ferry2:
 	idle:
 		Filename: bits/ferry.png
 	open:

--- a/mods/hv/sequences/vehicles.yaml
+++ b/mods/hv/sequences/vehicles.yaml
@@ -363,7 +363,16 @@ repairtank:
 		Filename: bits/units-icons.png
 		Start: 30
 
+# TODO: Change one of them both below later
 apc:
+	idle:
+		Filename: bits/apc.png
+		Facings: 8
+	icon:
+		Filename: bits/units-icons.png
+		Start: 13
+
+apc2:
 	idle:
 		Filename: bits/apc.png
 		Facings: 8

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -96,7 +96,7 @@ MissileTankRocket:
 			None: 8
 			Steel: 75
 			Light: 75
-			Heavy: 75
+			Heavy: 79
 			Concrete: 75
 	Warhead@Incendiary: TreeDamage
 		Damage: 6000
@@ -249,7 +249,7 @@ StealthTankMissile:
 			None: 10
 			Steel: 100
 			Light: 100
-			Heavy: 100
+			Heavy: 105
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Damage: 7250


### PR DESCRIPTION
Motivation: gives an unique touch for them, attempting to be as balanced as possible.

- All Synapol transports: have a bit more HP, but a bit slower
- All Yuruki tranports: have a bit less HP, but are a bit faster
- With these changes, I also changed slightly the damage on Missile Tank and Stealh Tank projectiles vs Heavy so it's more convenient when they are fighting transport units

This PR has some change ideas from: https://github.com/OpenHV/OpenHV/pull/998, more specifically this commit: https://github.com/OpenHV/OpenHV/pull/998/commits/55df098a00f4a2d1ab74fc3e0194eea5c4321d4c

**NOTE:** This PR needs more graphics for Tank and Naval Transports.