### PR TITLE
Rebalanced Balloon range

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -379,12 +379,12 @@ BALLOON:
 	Health:
 		HP: 8000
 	RevealsShroud:
-		Range: 24c0
-		MinRange: 12c0
+		Range: 20c0
+		MinRange: 10c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 12c0
+		Range: 10c0
 		Type: GroundPosition
 	Aircraft:
 		Speed: 70


### PR DESCRIPTION
Turns out `24c0` was a bit too much.