### PR TITLE
Reorganize Main Base and Ore Smelters ordering on the construction panel

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -44,7 +44,7 @@ BASE:
 		Prerequisite: bots
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 900
+		BuildPaletteOrder: 160
 		BuildLimit: 1
 		Description: actor-base.description
 		Prerequisites: outpost, ~base.yi
@@ -1040,6 +1040,7 @@ ORESMELT:
 		Category: Buildings
 	Buildable:
 		Queue: Building
+		BuildPaletteOrder: 130
 		Description: actor-oresmelt.description
 		Prerequisites: ~structures.sc, techcenter
 	HitShape:


### PR DESCRIPTION
Following the idea of this issue: https://github.com/OpenHV/OpenHV/issues/1038

Maybe we forgot to discuss on Matrix. At least the positioning should be better with this PR, so it doesn't shift Ore Smelters one position to the right.

**NOTE:** I dunno how to make a single Main Base button always visible only for the faction.