### PR TITLE
Recode ImpactAirWarhead to ValidateTriggerWarhead.

### DIFF
--- a/OpenRA.Mods.HV/Warheads/FireRadiusWarhead.cs
+++ b/OpenRA.Mods.HV/Warheads/FireRadiusWarhead.cs
@@ -13,13 +13,12 @@ using System;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.HV.Warheads
 {
 	[Desc("Fires a defined amount of weapons with their maximum range in a wave pattern.")]
-	public class FireRadiusWarhead : ImpactAirWarhead, IRulesetLoaded<WeaponInfo>
+	public class FireRadiusWarhead : ValidateTriggerWarhead, IRulesetLoaded<WeaponInfo>
 	{
 		[WeaponReference]
 		[FieldLoader.Require]
@@ -45,24 +44,12 @@ namespace OpenRA.Mods.HV.Warheads
 
 		public override void DoImpact(in Target target, WarheadArgs args)
 		{
-			var firedBy = args.SourceActor;
-			if (!target.IsValidFor(firedBy))
+			if (!ValidateTrigger(target, args))
 				return;
 
+			var firedBy = args.SourceActor;
 			var world = firedBy.World;
 			var map = world.Map;
-
-			if (target.Type == TargetType.Invalid)
-				return;
-
-			var pos = target.CenterPosition;
-			var actorAtImpact = ImpactActors ? ActorTypeAtImpact(world, pos, firedBy) : ImpactActorType.None;
-
-			// If there's either a) an invalid actor, or b) no actor and invalid terrain, we don't trigger the effect(s).
-			if (actorAtImpact == ImpactActorType.Invalid)
-				return;
-			else if (actorAtImpact == ImpactActorType.None && !IsValidAgainstTerrain(world, pos))
-				return;
 
 			var epicenter = AroundTarget && args.WeaponTarget.Type != TargetType.Invalid
 				? args.WeaponTarget.CenterPosition

--- a/OpenRA.Mods.HV/Warheads/FireShrapnelWarhead.cs
+++ b/OpenRA.Mods.HV/Warheads/FireShrapnelWarhead.cs
@@ -14,12 +14,11 @@ using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.HV.Warheads
 {
-	public class FireShrapnelWarhead : ImpactAirWarhead, IRulesetLoaded<WeaponInfo>
+	public class FireShrapnelWarhead : ValidateTriggerWarhead, IRulesetLoaded<WeaponInfo>
 	{
 		[WeaponReference]
 		[FieldLoader.Require]
@@ -54,24 +53,12 @@ namespace OpenRA.Mods.HV.Warheads
 
 		public override void DoImpact(in Target target, WarheadArgs args)
 		{
-			var firedBy = args.SourceActor;
-			if (!target.IsValidFor(firedBy))
+			if (!ValidateTrigger(target, args))
 				return;
 
+			var firedBy = args.SourceActor;
 			var world = firedBy.World;
 			var map = world.Map;
-
-			if (target.Type == TargetType.Invalid)
-				return;
-
-			var pos = target.CenterPosition;
-			var actorAtImpact = ImpactActors ? ActorTypeAtImpact(world, pos, firedBy) : ImpactActorType.None;
-
-			// If there's either a) an invalid actor, or b) no actor and invalid terrain, we don't trigger the effect(s).
-			if (actorAtImpact == ImpactActorType.Invalid)
-				return;
-			else if (actorAtImpact == ImpactActorType.None && !IsValidAgainstTerrain(world, pos))
-				return;
 
 			var epicenter = AroundTarget && args.WeaponTarget.Type != TargetType.Invalid
 				? args.WeaponTarget.CenterPosition


### PR DESCRIPTION
ImpactAirWarhead was inherited from AS, but due to bitrot and confusion over the initial approach, the reasons stopped being clear enough on why it got implemented in the first place.

This refactor shifts all trigger validation logic to the abstract base class from the downstream usecases, to promote the trigger validation as the primary function and downplay the Air targettype grant as an implementation detail.

Also dropped ImpactActors tag to explicitly rely on TargetType filtering alone.

TO-DO: Write case study properly explaining the underlying reason.