### PR TITLE
Encyclopedia update

### DIFF
--- a/mods/hv/languages/rules/en.ftl
+++ b/mods/hv/languages/rules/en.ftl
@@ -534,10 +534,10 @@ actor-broker =
    .name = Broker
 
 actor-jetpacker =
-   .description = Elite airborn vehicle.
+   .description = Elite airborne vehicle.
     Armed with heavy machine gun.
-      Strong vs Pods, Light Vehicles and Aircraft.
-      Weak vs Tanks and Buildings.
+      Strong vs Pods, Light Vehicles and Aircraft
+      Weak vs Tanks and Buildings
    .name = Jetpacker
 
 actor-blaster =

--- a/mods/hv/languages/rules/en.ftl
+++ b/mods/hv/languages/rules/en.ftl
@@ -686,7 +686,7 @@ actor-artillery =
       Weak vs Tanks
 
 actor-radartank =
-   .description = Can detect cloaked units.n
+   .description = Can detect cloaked units
     Range extends when deployed.
       Unarmed
    .name = Reconnaissance Tank

--- a/mods/hv/languages/rules/en.ftl
+++ b/mods/hv/languages/rules/en.ftl
@@ -690,7 +690,11 @@ actor-radartank =
     Range extends when deployed.
       Unarmed
    .name = Reconnaissance Tank
-   .deployed--name = Reconnaissance Tank (deployed)
+   .encyclopedia = The radar tank is an universal utility and support unit, that provides reconnaissance. It can also detect cloaked units in a certain range. Its range can be extended by deploying it, though it won't be able to move when deployed.
+     
+     Unarmed
+     
+     Availability: Universal
 
 actor-repairtank =
    .name = Mobile Repair Vehicle

--- a/mods/hv/languages/rules/en.ftl
+++ b/mods/hv/languages/rules/en.ftl
@@ -527,7 +527,7 @@ actor-technician =
 
 actor-broker =
    .description = Financial analyst.
-    Invests into stock market for dividents.
+    Invests into stock market for dividends.
     Capable of remotely stealing money
     from bases and storages.
       Unarmed

--- a/mods/hv/languages/rules/en.ftl
+++ b/mods/hv/languages/rules/en.ftl
@@ -856,7 +856,7 @@ actor-aatank2 =
      Availability: Yuruki
 
 actor-apc =
-   .name = Transport Tank
+   .name = APC
    .description = Can transport pods.
       Has fireports for garrisoned units.
    .encyclopedia = Armored Personal Carriers (APC) are durable transport tanks, that can load up to 8 tons of cargo, the equivalent of 5 pods. It is used to carry pods, giving them better protection, while still being able to fire through firing ports. It was designed to conduct assault missions, when you don't have enough resources to produce tanks.

--- a/mods/hv/languages/rules/en.ftl
+++ b/mods/hv/languages/rules/en.ftl
@@ -592,7 +592,7 @@ actor-flamer =
    .description = Short range flame thrower.
       Strong vs Pods and Buildings
       Weak vs Tanks
-   .name = Flame
+   .name = Flamer
    .encyclopedia = The flamer pod is armed with a powerful short range flame thrower, designed to annihilate pods and buildings. While it is powerful against buildings, it has a lower health than other pods.
 
      {actor-flamer.description}

--- a/mods/hv/languages/rules/en.ftl
+++ b/mods/hv/languages/rules/en.ftl
@@ -612,7 +612,7 @@ actor-torpedoboat =
 actor-submarine =
    .name = Submarine
    .generic-name = Submarine
-   .description = Submarine with powerful torpedos.
+   .description = Submarine with powerful torpedoes.
       Strong vs Water
       Can't attack Pods, Buildings, Vehicles or Air
 

--- a/mods/hv/languages/rules/en.ftl
+++ b/mods/hv/languages/rules/en.ftl
@@ -151,6 +151,11 @@ actor-gunship =
       Strong vs Pods, Buildings and Aircraft
       Weak vs Tanks
    .name = Gun Ship
+   .encyclopedia = The gun ship is a fast plane, armed with a heavy machine gun. It's a versatile unit, often used to harass the opponents' mining towers and outposts.
+
+     {actor-gunship.description}
+
+     Availability: Yuruki
 
 actor-jet =
    .description = Fast Attack Ship
@@ -158,17 +163,32 @@ actor-jet =
       Weak vs Tanks and Pods
       Can't target Aircraft
    .name = Speeder
+   .encyclopedia = The speeder is an air-to-ground plane, armed with a plasma canon that can destroy buildings easily. It is slower but more durable than the attack aircraft.
+
+     {actor-jet.description}
+
+     Availability: Yuruki
 
 actor-copter =
    .name = Attack Helicopter
    .description = Small Helicopter Gunship
       Strong vs Pods, Buildings and Aircraft
       Weak vs Tanks
+   .encyclopedia = The attack helicopter is a small helicopter, armed with a turret heavy machine gun. It's a versatile unit, often used to harass the opponents' mining towers and outposts.
+
+     {actor-copter.description}
+
+     Availability: Synapol
 
 actor-saucer =
    .name = Scout Saucer
    .description = Reconnaissance air unit.
       Unarmed
+   .encyclopedia = A disc shaped aircraft with good maneuverability. It's not suited for combat, but for reconnaissance missions. Due to its unusual shape and low radar reflectance, oftentimes civilians will report this sighting to the authorities first.
+
+     {actor-saucer.description}
+
+     Availability: Yuruki
 
 actor-banshee =
    .name = Banshee
@@ -176,12 +196,22 @@ actor-banshee =
       Strong vs Buildings
       Weak vs Tanks and Pods
       Can't target Aircraft
+   .encyclopedia = The banshee is a more durable and slow helicopter, that launches powerful missiles onto the ground. It is particularly strong against buildings.
+
+     {actor-banshee.description}
+
+     Availability: Synapol
 
 actor-chopper =
    .name = Transport Helicopter
    .description = Vehicle Transport Helicopter.
       Can load pods
       and lift one vehicle.
+   .encyclopedia = The chopper is a heavy transport aircraft, than can load up to 5 tons of cargo, the equivalent of 8 pods. It can also lift one vehicle.
+
+     {actor-chopper.description}
+
+     Availability: Synapol
 
 actor-chopper-husk-name = Crashing Transport Helicopter
 
@@ -189,19 +219,45 @@ actor-balloon =
    .name = Scout Balloon
    .description = Reconnaissance air unit.
      Unarmed
+   .encyclopedia = A reconnaissance air unit. It's slower than Yuruki's saucer, but it grants more visibility range.
+
+     Unarmed
+
+     Availability: Synapol
 
 actor-dropship =
    .name = Heavy Transport Dropship
    .description = Vehicle Transport Shuttle.
       Can load pods
       and lift one vehicle.
+   .encyclopedia = The dropship is a heavy transport aircraft, than can load up to 5 tons of cargo, the equivalent of 8 pods. It can also lift one vehicle.
+
+     {actor-dropship.description}
+
+     Availability: Yuruki
 
 actor-dropship-husk-name = Crashing Transport Dropship
 actor-drone-name = Drone
 actor-landedpod-name = Landed Pod
 actor-bomber-name = Athmospheric Bomber
+actor-bomber-encyclopedia = The bomber is a fast plane that drops salves of bombs onto the target. They can be launched from the Yuruki radar.
+
+  Strong vs Buildings
+  Weak vs Pods and Tanks
+
+  Availability: Non-trainable
 actor-cargoship-name = Supply Aircraft
+actor-cargoship-encyclopedia = The cargoship is an universal cargo unit that transports units for trading. It's used to deliver units onto the Trade Platform.
+
+  Unarmed
+
+  Availability: Non-trainable
 actor-airlifter-name = Transport Aircraft
+actor-airlifter-encyclopedia = The airlifter paradrops loaded units onto the ground. It is used in drop zone buildings to deliver mercenary tanks.
+
+  Unarmed
+
+  Availability: Non-trainable
 
 ## Animals
 actor-beast =
@@ -490,6 +546,11 @@ actor-rifleman =
       Strong vs Pods
       Weak vs Tanks and Buildings
    .name = Rifleman
+   .encyclopedia = The most generic pod. It is a small land vehicle controlled by a human. They are the modern solution for infantry, and offer a fast and cheap production. Pods come in different variants, with different armaments and abilities, but the Rifleman one has a simple machine gun equipped. As it is universal, both Yuruki and Synapol use it.
+
+     {actor-rifleman.description}
+
+     Availability: Universal
 
 actor-rocketeer =
    .description = Fast support vehicle.
@@ -497,6 +558,11 @@ actor-rocketeer =
       Strong vs Tanks and Aircraft
       Weak vs Pods
    .name = Rocketeer
+   .encyclopedia = The rocketeer is equipped with a rocket launcher, and is designed to handle pretty much everything, except pods. It's its versatility that makes it a common pod used in every situation.
+
+     {actor-rocketeer.description}
+
+     Availability: Synapol
 
 actor-mortar =
    .description = Fast support vehicle.
@@ -504,6 +570,11 @@ actor-mortar =
       Strong vs Pods and Buildings
       Weak vs Tanks
    .name = Mortar
+   .encyclopedia = The mortar pod is a fast support vehicle, armed with a mortar gun, particularly powerful against both pods and buildings. It was designed by the Synapol Corporations to handle small outpost, often defended with pods only.
+
+      {actor-mortar.description}
+
+     Availability: Synapol
 
 actor-sniper =
    .description = Long range sniper vehicle.
@@ -511,12 +582,22 @@ actor-sniper =
       Strong vs Pods
       Weak vs Tanks and Buildings
    .name = Sniper
+   .encyclopedia = The sniper pod is an advanced unit, capable of generating an invisibility cloak on itself. It's armed with a long range sniper, than can take down pods in one shot, with speed and agility.
+
+     {actor-sniper.description}
+
+     Availability: Yuruki
 
 actor-flamer =
    .description = Short range flame thrower.
       Strong vs Pods and Buildings
       Weak vs Tanks
    .name = Flame
+   .encyclopedia = The flamer pod is armed with a powerful short range flame thrower, designed to annihilate pods and buildings. While it is powerful against buildings, it has a lower health than other pods.
+
+     {actor-flamer.description}
+
+     Availability: Synapol
 
 actor-technician =
    .description = Field engineer.
@@ -524,6 +605,11 @@ actor-technician =
     Repairs pods.
       Unarmed
    .name = Technician
+   .encyclopedia = The universal field engineer. Its first ability is to infiltrate and capture enemy structures, changing their allegiance: it is often used to capture enemy mining towers. Its second ability is to repair allied pods, on the battle field.
+
+     {actor-technician.description}
+
+     Availability: Universal
 
 actor-broker =
    .description = Financial analyst.
@@ -532,6 +618,11 @@ actor-broker =
     from bases and storages.
       Unarmed
    .name = Broker
+   .encyclopedia = The broker pod is an advanced pod that can invest in the stock market for a constant stream of revenue. It can also tap into an opponent's base or storage and initiate forged wire transfers to remotely steal that enemy's cash.
+
+     {actor-broker.description}
+
+     Availability: Universal
 
 actor-jetpacker =
    .description = Elite airborne vehicle.
@@ -539,11 +630,21 @@ actor-jetpacker =
       Strong vs Pods, Light Vehicles and Aircraft
       Weak vs Tanks and Buildings
    .name = Jetpacker
+   .encyclopedia = The ultimate pod: the jetpacker. It was designed by an independent lab, allowing its universal availability. It can handle pods, light vehicles and aircraft well. The fact that it's an airborne pod makes it less vulnerable to other pods.
+
+     {actor-jetpacker.description}
+
+     Availability: Universal
 
 actor-blaster =
    .description = Remote controlled mine.
     Explodes when reaches enemy.
    .name = Blaster
+   .encyclopedia = The only pod that isn't controlled by a human: this pod is controlled from the base, and sent to self destruct at enemy positions. It is mainly used to raid against enemy structures, inflicting important damages. It is thought less durable than other pods.
+
+     {actor-blaster.description}
+
+     Availability: Yuruki
 
 actor-shocker =
    .description = Fast support vehicle.
@@ -551,10 +652,20 @@ actor-shocker =
       Strong vs Tanks and Aircraft
       Weak vs Pods
    .name = Shocker
+   .encyclopedia = The shocker pod is equipped with a small but yet powerful laser zap, and is designed to handle pretty much everything, except pods. It's its versatility that makes it a common pod used in every situation.
+
+     {actor-shocker.description}
+
+     Availability: Yuruki
 
 meta-minipod =
    .name = Civilian
    .generic-name = Civilian
+   .encyclopedia = Pods are not only for combat, but also for civilian transport.
+
+     Unarmed
+
+     Availability: Universal/Non-trainable
 
 ## Props
 actor-lamppost-name = Lamp Post
@@ -587,6 +698,11 @@ actor-lightboat =
    .description = Versatile light boat.
       Strong vs Aircrafts, Navy and Pods
       Weak vs Vehicles and Buildings
+   .encyclopedia = The light boat is designed for patrol and fast assaults. It's the fastest boat but also the less durable. It has a heavy turreted chaingun install, as well as a flak turret.
+
+     {actor-lightboat.description}
+
+     Availability: Yuruki
 
 actor-patrolboat =
    .name = Patrol boat
@@ -594,6 +710,11 @@ actor-patrolboat =
    .description = Versatile light boat.
       Strong vs Aircrafts, Navy and Pods
       Weak vs Vehicles and Buildings
+   .encyclopedia = The patrol boat is designed for patrol and fast assaults. It's the fastest boat but also the less durable. It has a heavy turreted chaingun install, as well as a flak turret.
+
+     {actor-patrolboat.description}
+
+     Availability: Synapol
 
 actor-mercboat =
    .name = Mercenary Boat
@@ -601,6 +722,11 @@ actor-mercboat =
    .description = A boat with a turret.
       Strong vs Vehicles
       Weak vs Pods
+   .encyclopedia = The mercenary boat is a fast boat, armed with a turret. Its turret is powerful against other ships.
+
+     {actor-mercboat.description}
+
+     Availability: Non-trainable
 
 actor-torpedoboat =
    .name = Torpedo Boat
@@ -608,6 +734,11 @@ actor-torpedoboat =
    .description = A boat with torpedo launchers.
       Strong vs Water
       Can't attack Ground or Air
+   .encyclopedia = The torpedo boat is designed to counter fast ship assaults. It has two torpedo launchers onboard that can take down multiple boats on its own.
+
+     {actor-torpedoboat.description}
+
+     Availability: Yuruki
 
 actor-submarine =
    .name = Submarine
@@ -615,24 +746,44 @@ actor-submarine =
    .description = Submarine with powerful torpedoes.
       Strong vs Water
       Can't attack Pods, Buildings, Vehicles or Air
+   .encyclopedia = The submarine is a stealth ship, capable of going underwater. It has a torpedo launcher onboard than can take down a large ship in a few strike. It's slower than Yuruki's torpedo boat though.
+
+     {actor-submarine.description}
+
+     Availability: Synapol
 
 actor-railgunboat =
    .name = Railgun Boat
    .generic-name = Boat
    .description = A heavy boat with a rail gun.
       Strong vs Vehicles, Pods and Buildings
+   .encyclopedia = The railgun boat is a heavy ship capable of handling every situation possible. It's armed with a turreted railgun canon, that's particularly powerful against buildings.
+
+     {actor-railgunpod.description}
+
+     Availability: Synapol
 
 actor-lightningboat =
    .name = Lightning Boat
    .generic-name = Boat
    .description = A heavy boat with a lightning gun.
       Strong vs Vehicles, Pods and Buildings
+   .encyclopedia = The lightning boat is a heavy ship capable of handling every situation possible. It's armed with a 360 degrees laser zap, that's particularly powerful against buildings.
+
+     {actor-lightningboat.description}
+
+     Availability: Yuruki
 
 actor-boomer =
    .name = Missile Submarine
    .generic-name = Submarine
    .description = A submarine with powerful long range missiles.
       Strong vs Vehicles, Pods and Buildings
+   .encyclopedia = This heavy submarine is capable of launching ballistic missiles to a high range. As a submarine, it has the capability of going underwater.
+
+     {actor-boomer.description}
+
+     Availability: Synapol
 
 actor-slcm-name = Submarine-launched cruise missile
 
@@ -640,6 +791,11 @@ actor-carrier =
    .description = Launches aerial autonomous attack vessels.
       Strong vs Vehicles, Pods and Buildings
    .name = Drone Ship
+   .encyclopedia = This heavy ship has a drone launch bay, containing three aerial autonomous drones, that can attack any target at a certain range. When a drone is shot down, it's reproduced. The drones have to reload themselves in the launch bay.
+
+     {actor-carrier.description}
+
+     Availability: Yuruki
 
 actor-ferry =
    .name = Ferry
@@ -647,6 +803,11 @@ actor-ferry =
    .description = General-purpose naval transport.
     Can carry pods.
       Unarmed
+   .encyclopedia = The ferry is a heavy naval transporter. It can load up to 6 tons of cargo, the equivalent of 10 pods. It is quite slow but very durable. It can land on shores to load or unload its cargo.
+
+     {actor-ferry.description}
+
+     Availability: Universal
 
 actor-mineship =
    .name = Naval Minelayer
@@ -656,6 +817,10 @@ actor-mineship =
     while avoiding ally units.
       Can detect enemy mines.
       Unarmed
+   .encyclopedia = The naval minelayer is able to lay smart mines that explode on enemy units, while avoiding ally units. The mines can also be triggered manually. Minelayers can also detect enemy mines at a certain range. It has to reload at an harbor.
+     Unarmed
+
+     Availability: Universal/Faction design can vary
 
 ## Vehicles
 actor-mbt =
@@ -663,27 +828,51 @@ actor-mbt =
    .description = Main Battle Tank.
       Strong vs Vehicles
       Weak vs Pods
+   .encyclopedia = Assault tanks are a great solution to deal against any other tank. Their turreted canon allow them to move at a decent speed, while still shooting down enemies. They also are decent against buildings, in groups.
+
+     {actor-mbt.description}
+
+     Availability: Universal/Faction design can vary
 
 actor-aatank =
    .description = Mobile tank with AA missiles.
       Strong vs Aircraft
       Cannot attack grounds units.
    .name = Mobile AA
+   .encyclopedia = Mobile AA turrets are yet, less powerful than stationary AA turrets, but they can pursue the enemy when it gets out of range. While they are a universal unit, factions use different AA armaments.
 
-actor-aatank2-description = Mobile tank with lightning gun.
+     {actor-aatank.description}
+
+     Availability: Synapol
+
+actor-aatank2 =
+   .description = Mobile tank with lightning gun.
       Strong vs Aircraft
       Cannot attack grounds units.
+   .encyclopedia = Mobile AA turrets are yet, less powerful than stationary AA turrets, but they can pursue the enemy when it gets out of range. While they are a universal unit, factions use different AA armaments.
+
+     {actor-aatank2.description}
+
+     Availability: Yuruki
 
 actor-apc =
    .name = Transport Tank
    .description = Can transport pods.
       Has fireports for garrisoned units.
+   .encyclopedia = Armored Personal Carriers (APC) are durable transport tanks, that can load up to 8 tons of cargo, the equivalent of 5 pods. It is used to carry pods, giving them better protection, while still being able to fire through firing ports. It was designed to conduct assault missions, when you don't have enough resources to produce tanks.
+
+     Availability: Universal
 
 actor-artillery =
    .name = Artillery
    .description = Mobile long range weapon.
       Strong vs Pods and Buildings
       Weak vs Tanks
+   .encyclopedia = Armed with a long range artillery canon, this mobile artillery vehicle is extremely powerful against pods and buildings, while still being decently strong against other units. It was designed to power down enemies defenses while other units were assaulting a base.
+
+     {actor-artillery.description}
+
+     Availability: Universal
 
 actor-radartank =
    .description = Can detect cloaked units
@@ -691,9 +880,9 @@ actor-radartank =
       Unarmed
    .name = Reconnaissance Tank
    .encyclopedia = The radar tank is an universal utility and support unit, that provides reconnaissance. It can also detect cloaked units in a certain range. Its range can be extended by deploying it, though it won't be able to move when deployed.
-     
+
      Unarmed
-     
+
      Availability: Universal
 
 actor-repairtank =
@@ -701,6 +890,11 @@ actor-repairtank =
    .generic-name = Tank
    .description = Repairs nearby tanks.
       Unarmed
+   .encyclopedia = The repair tank is a fast field engineer vehicle, that can repair tanks using a special beam.
+
+     Unarmed
+
+     Availability: Universal
 
 actor-minelayer =
    .description = Lays smart mines
@@ -708,24 +902,44 @@ actor-minelayer =
     while avoiding ally units.  Can detect enemy mines.
       Unarmed
    .name = Minelayer
+   .encyclopedia = The minelayer is a fast and agile support unit, that can lay smart mines, that explode on enemy units; while avoiding ally units. They can also be triggered manually. It also has the ability to detect enemy mines at a certain range. It has to reload on trade platforms.
+
+     Unarmed
+
+     Availability: Universal
 
 actor-railguntank =
    .name = Railgun Tank
    .generic-name = Tank
    .description = A powerful tank which shoots laser.
       Strong vs Pods, Vehicles and Buildings
+   .encyclopedia = The railgun tank is the ultimate tank, able of handling every type of unit. It's armed with a powerful laser canon, and has a heavy armor.
+
+     {actor-railguntank.description}
+
+     Availability: Synapol
 
 actor-lightningtank =
    .description = Fires electric discharges.
       Strong vs Pods, Vehicles and Buildings
    .name = Lightning Tank
    .generic-name = Tank
+   .encyclopedia = The lightning tank is the ultimate tank, able of handling every type of unit. It's armed with a powerful laser zap, and has a heavy armor.
+
+     {actor-lightningtank.description}
+
+     Availability: Yuruki
 
 actor-stealthtank =
    .description = Cloaked missile tank.
       Strong vs Vehicles and Buildings
       Weak vs Pods
    .name = Stealth Tank
+   .encyclopedia = The stealth tank is a modern tank, able of deploying a cloak on itself. It is armed with a powerful missile launcher, extremely powerful against buildings. It is yet less versatile than the lightning tank, it is stronger against buildings.
+
+     {actor-stealthtank.description}
+
+     Availability: Yuruki
 
 actor-merctank =
    .name = Mercenary Tank
@@ -733,6 +947,11 @@ actor-merctank =
    .description = Main battle tank.
       Strong vs Vehicles
       Weak vs Pods
+   .encyclopedia = The mercenary tank is a generic tank, that can be only obtained through the drop zone buildings. Its canon cannot rotate like other battles tanks though.
+
+     {actor-merctank.description}
+
+     Availability: Non-trainable
 
 actor-dualmerctank-description = Double barreled tank.
       Strong vs Vehicles
@@ -743,11 +962,21 @@ actor-ecmtank =
    .generic-name = ECM Tank
    .description = Disables units for a brief moment.
       Jams incoming missiles.
+   .encyclopedia = The electronic countermeasure (ECM) tank can overload enemy weaponry systems with a controlled beam that disables all electronic system units for a brief moment, disabling them completely. The effect only lasts a few seconds. Its other ability is to deflect incoming enemy missiles.
+
+     Unarmed
+
+     Availability: Synapol
 
 actor-dualartillery =
    .name = Dual Artillery
    .description = Double barreled artillery tank.
       Strong vs Pods, Vehicles and Buildings
+   .encyclopedia = This vehicle is an upgrade of the artillery tank. It's twice bigger, has more range, and fires two bombshells at once. Its range is extremely higher, and it's damaging against any type of armor. Due to intellectual property disputes, this design is rarely seen on the battlefield.
+
+     {actor-dualartillery.description}
+
+     Availability: Non-trainable
 
 actor-builder =
    .description = Deploys into outpost which
@@ -755,6 +984,11 @@ actor-builder =
     and allows base reconstruction.
       Unarmed
    .name = Builder
+   .encyclopedia = The builder is an important support unit, allowing the deployment of outpost which grants additional build radius, and allow base reconstruction.
+
+     Unarmed
+
+     Availability: Universal/Faction design can vary
 
 actor-collector-name = Collector
 
@@ -762,6 +996,11 @@ actor-miner =
    .description = Builds mining facilities.
       Unarmed
    .name = Miner
+   .encyclopedia = The role of this vehicle is to deploy mining facilities, allowing the production of resources, that are then transformed into cash at the storage building.
+
+     Unarmed
+
+     Availability: Universal
 
 actor-missiletank =
    .name = Missile Tank
@@ -769,12 +1008,22 @@ actor-missiletank =
    .description = A tank which shoots missiles.
       Strong vs Vehicles and Buildings
       Weak vs Pods
+   .encyclopedia = The missile tank is an agile tank, able to fire from a turret, while still moving decently fast. It is armed with a powerful missile launcher, extremely powerful against buildings. It is yet less versatile than the railgun tank, it is stronger against buildings.
+
+     {actor-missiletank.description}
+
+     Availability: Synapol
 
 actor-hackertank =
    .description = Temporarily changes allegiance of targeted units.
       Disrupts satellite video links
       and obscures the battlefield when deployed.
    .name = Hacker Tank
+   .encyclopedia = The hacker tank contains equipment to penetrate firewalls of individual units and interfer with their command and control software so they will accept orders from the enemy and engage in friendly fire. The effective change of allegiance is permanent, until the hacker tank gets destroyed or changes the target. It can only have one controlled unit at a time. Its other ability is to obscure the opponent's battlefield on its surroundings when deployed.
+
+     Unarmed
+
+     Availability: Yuruki
 
 actor-buggy =
    .name = Ramp Buggy
@@ -782,6 +1031,11 @@ actor-buggy =
    .description = Fires a machine gun.
       Strong vs Pods
       Weak vs Tanks, Buildings
+   .encyclopedia = The ramp buggy is a fast anti-pod vehicle, that has a turret heavy machine gun, capable of destroying a group of pods by itself. It is Synapol's solution to the Yuruki gatling bike: while it is slower, its machine gun is turreted, giving it an advantage.
+
+     {actor-buggy.description}
+
+     Availability: Synapol
 
 actor-bike =
    .name = Gatling Bike
@@ -789,6 +1043,11 @@ actor-bike =
    .description = Fires a machine gun.
       Strong vs Pods
       Weak vs Tanks, Buildings
+   .encyclopedia = The gatling bike is a fast anti-pod vehicle, that has a powerful heavy machine gun, capable of destroying a group of pods by itself.
+
+     {actor-bike.description}
+
+     Availability: Yuruki
 
 actor-tanker1 =
    .description = Transports resources to the headquarter.
@@ -799,16 +1058,31 @@ actor-tanker2 =
    .description = Collects resources at mining towers.
       Unarmed
    .name = Empty Resource Transporter
+   .encyclopedia = The tanker is a resource transporter, that moves from mining towers to storage building to collect and depose resources.
+
+     Unarmed
+
+     Availability: Universal
 
 actor-cvit =
    .description = Moves cash to other players.
       Unarmed
    .name = Money Transport
+   .encyclopedia = The money transport moves cash to other players, in order to help them financially.
+
+     Unarmed
+
+     Availability: Universal
 
 actor-mothership =
    .name = Mothership
    .description = Launches aerial autonomous attack vessels.
       Strong vs Everything
+   .encyclopedia = When the Yuruki colony on Mars started their battleship design program, the Synapol Corporations had to design themselves a massive air unit to counter the battleship. The mothership was their solution. It's a real floating city: it regroups a crew of 2,500 men, and has many different quarters, some being science labs, other armament testing... It is armed with two powerful plasma turreted canon that can target ground structures, and with a drone bay, containing five of them. When a drone is destroyed, another one is immediately reproduced.
+
+     {actor-mothership.description}
+
+     Availability: Synapol
 
 actor-mothership-husk =
    .name = Mothership Husk
@@ -821,6 +1095,11 @@ actor-battleship =
    .description = Aerial artillery bombardment.
       Strong vs Ground units
       Can't target Aircraft
+   .encyclopedia = The battleship is a massive air unit, regrouping a crew of 1,200 men. Its design was launched by the Yuruki colony on Mars a few 15 years ago, and took 10 years to design, test and create. It is no more a prototype and is now used by the Yuruki paramilitary forces. It is armed with 2 synchronized artillery turrets, that launches aerial bombardment, destroying in a few seconds a whole outpost.
+
+     {actor-battleship.description}
+
+     Availability: Yuruki
 
 actor-battleship-husk =
    .name = Battleship Husk

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -10,6 +10,10 @@ GUNSHIP:
 		BuildPaletteOrder: 30
 		Prerequisites: ~starport.yi
 		Description: actor-gunship.description
+	Encyclopedia:
+		Description: actor-gunship.encyclopedia
+		Order: 2
+		Category: Aircraft
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -71,6 +75,10 @@ JET:
 		BuildPaletteOrder: 50
 		Prerequisites: techcenter, ~starport.yi
 		Description: actor-jet.description
+	Encyclopedia:
+		Description: actor-jet.encyclopedia
+		Order: 10
+		Category: Aircraft
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -145,6 +153,10 @@ COPTER:
 		BuildPaletteOrder: 30
 		Prerequisites: ~starport.sc
 		Description: actor-copter.description
+	Encyclopedia:
+		Description: actor-copter.encyclopedia
+		Order: 5
+		Category: Aircraft
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -190,6 +202,10 @@ SAUCER:
 		BuildPaletteOrder: 20
 		Prerequisites: ~starport.yi
 		Description: actor-saucer.description
+	Encyclopedia:
+		Description: actor-saucer.encyclopedia
+		Order: 0
+		Category: Aircraft
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -230,6 +246,10 @@ BANSHEE:
 		BuildPaletteOrder: 40
 		Prerequisites: techcenter, ~starport.sc
 		Description: actor-banshee.description
+	Encyclopedia:
+		Description: actor-banshee.encyclopedia
+		Order: 15
+		Category: Aircraft
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -282,6 +302,10 @@ CHOPPER:
 		BuildPaletteOrder: 50
 		Prerequisites: ~starport.sc
 		Description: actor-chopper.description
+	Encyclopedia:
+		Description: actor-chopper.encyclopedia
+		Order: 25
+		Category: Aircraft
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -374,6 +398,10 @@ BALLOON:
 		BuildPaletteOrder: 20
 		Prerequisites: ~starport.sc
 		Description: actor-balloon.description
+	Encyclopedia:
+		Description: actor-balloon.encyclopedia
+		Order: 1
+		Category: Aircraft
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -416,6 +444,10 @@ DROPSHIP:
 		BuildPaletteOrder: 50
 		Prerequisites: ~starport.yi
 		Description: actor-dropship.description
+	Encyclopedia:
+		Description: actor-dropship.encyclopedia
+		Order: 20
+		Category: Aircraft
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -625,6 +657,10 @@ BOMBER:
 	HiddenUnderFog:
 		Type: GroundPosition
 		AlwaysVisibleRelationships: None
+	Encyclopedia:
+		Description: actor-bomber-encyclopedia
+		Order: 30
+		Category: Aircraft
 	WithFacingSpriteBody:
 	WithShadow:
 		Offset: 356, 256, 0
@@ -652,6 +688,10 @@ BOMBER:
 
 CARGOSHIP:
 	Inherits: ^CargoPlane
+	Encyclopedia:
+		Description: actor-cargoship-encyclopedia
+		Order: 35
+		Category: Aircraft
 	Aircraft:
 		TurnSpeed: 20
 		Speed: 150
@@ -667,6 +707,10 @@ CARGOSHIP:
 
 AIRLIFTER:
 	Inherits: ^CargoPlane
+	Encyclopedia:
+		Description: actor-airlifter-encyclopedia
+		Order: 40
+		Category: Aircraft
 	Aircraft:
 		TurnSpeed: 25
 		Speed: 200
@@ -692,6 +736,10 @@ MOTHERSHIP:
 		BuildPaletteOrder: 100
 		Prerequisites: ~starport.sc, techcenter, ~disabled
 		Description: actor-mothership.description
+	Encyclopedia:
+		Description: actor-mothership.encyclopedia
+		Order: 50
+		Category: Aircraft
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -813,6 +861,10 @@ BATTLESHIP:
 		BuildPaletteOrder: 100
 		Prerequisites: ~starport.yi, techcenter, ~disabled
 		Description: actor-battleship.description
+	Encyclopedia:
+		Description: actor-battleship.encyclopedia
+		Order: 45
+		Category: Aircraft
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:

--- a/mods/hv/rules/editor.yaml
+++ b/mods/hv/rules/editor.yaml
@@ -119,6 +119,7 @@ DROPSHIP.colorpicker:
 	-MapEditorData:
 	-GrantConditionOnDamageState:
 	-FloatingSpriteEmitter@Smoke:
+	-Encyclopedia:
 	RenderSprites:
 		Image: dropship
 		Palette: colorpicker

--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -8,6 +8,10 @@ RIFLEMAN:
 		Description: actor-rifleman.description
 		Prerequisites: ~module
 		BuildPaletteOrder: 10
+	Encyclopedia:
+		Description: actor-rifleman.encyclopedia
+		Order: 0
+		Category: Pods
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -44,6 +48,10 @@ ROCKETEER:
 		Description: actor-rocketeer.description
 		Prerequisites: ~module.sc
 		BuildPaletteOrder: 20
+	Encyclopedia:
+		Description: actor-rocketeer.encyclopedia
+		Order: 10
+		Category: Pods
 	Valued:
 		Cost: 225
 	Tooltip:
@@ -78,6 +86,10 @@ MORTAR:
 		Description: actor-mortar.description
 		Prerequisites: ~module.sc, factory
 		BuildPaletteOrder: 50
+	Encyclopedia:
+		Description: actor-mortar.encyclopedia
+		Order: 35
+		Category: Pods
 	Valued:
 		Cost: 150
 	Tooltip:
@@ -114,6 +126,10 @@ SNIPER:
 		Description: actor-sniper.description
 		Prerequisites: ~module.yi, radar
 		BuildPaletteOrder: 50
+	Encyclopedia:
+		Description: actor-sniper.encyclopedia
+		Order: 30
+		Category: Pods
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -161,6 +177,10 @@ FLAMER:
 		Description: actor-flamer.description
 		Prerequisites: ~module.sc, factory
 		BuildPaletteOrder: 40
+	Encyclopedia:
+		Description: actor-flamer.encyclopedia
+		Order: 25
+		Category: Pods
 	Valued:
 		Cost: 350
 	Tooltip:
@@ -198,6 +218,10 @@ TECHNICIAN:
 		Description: actor-technician.description
 		Prerequisites: ~module
 		BuildPaletteOrder: 30
+	Encyclopedia:
+		Description: actor-technician.encyclopedia
+		Order: 15
+		Category: Pods
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -254,6 +278,10 @@ BROKER:
 		Description: actor-broker.description
 		Prerequisites: trader
 		BuildPaletteOrder: 70
+	Encyclopedia:
+		Description: actor-broker.encyclopedia
+		Order: 16
+		Category: Pods
 	Valued:
 		Cost: 700
 	Tooltip:
@@ -328,6 +356,10 @@ JETPACKER:
 		Description: actor-jetpacker.description
 		Prerequisites: ~module, techcenter
 		BuildPaletteOrder: 60
+	Encyclopedia:
+		Description: actor-jetpacker.encyclopedia
+		Order: 40
+		Category: Pods
 	Valued:
 		Cost: 650
 	Tooltip:
@@ -371,6 +403,10 @@ BLASTER:
 		Description: actor-blaster.description
 		Prerequisites: ~module.yi, radar
 		BuildPaletteOrder: 40
+	Encyclopedia:
+		Description: actor-blaster.encyclopedia
+		Order: 20
+		Category: Pods
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -418,6 +454,10 @@ SHOCKER:
 		Description: actor-shocker.description
 		Prerequisites: ~module.yi
 		BuildPaletteOrder: 20
+	Encyclopedia:
+		Description: actor-shocker.encyclopedia
+		Order: 5
+		Category: Pods
 	Valued:
 		Cost: 225
 	Tooltip:
@@ -447,6 +487,10 @@ SHOCKER:
 
 MINIPOD1:
 	Inherits: ^MINIPOD
+	Encyclopedia:
+		Description: meta-minipod.encyclopedia
+		Order: 45
+		Category: Pods
 
 MINIPOD2:
 	Inherits: ^MINIPOD

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -14,6 +14,10 @@ LIGHTBOAT:
 		Prerequisites: ~harbor.yi
 		BuildPaletteOrder: 10
 		Description: actor-lightboat.description
+	Encyclopedia:
+		Description: actor-lightboat.encyclopedia
+		Order: 0
+		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -58,6 +62,10 @@ PATROLBOAT:
 		Prerequisites: ~harbor.sc
 		BuildPaletteOrder: 10
 		Description: actor-patrolboat.description
+	Encyclopedia:
+		Description: actor-patrolboat.encyclopedia
+		Order: 5
+		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -107,6 +115,10 @@ MERCBOAT:
 		Prerequisites: ~disabled
 		BuildPaletteOrder: 90
 		Description: actor-mercboat.description
+	Encyclopedia:
+		Description: actor-mercboat.encyclopedia
+		Order: 60
+		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -149,6 +161,10 @@ TORPEDOBOAT:
 		Prerequisites: ~harbor.yi, radar
 		BuildPaletteOrder: 30
 		Description: actor-torpedoboat.description
+	Encyclopedia:
+		Description: actor-torpedoboat.encyclopedia
+		Order: 10
+		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -188,6 +204,10 @@ SUBMARINE:
 		Prerequisites: ~harbor.sc, radar
 		BuildPaletteOrder: 30
 		Description: actor-submarine.description
+	Encyclopedia:
+		Description: actor-submarine.encyclopedia
+		Order: 15
+		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -227,6 +247,10 @@ RAILGUNBOAT:
 		Prerequisites: ~harbor.sc, techcenter
 		BuildPaletteOrder: 50
 		Description: actor-railgunboat.description
+	Encyclopedia:
+		Description: actor-railgunboat.encyclopedia
+		Order: 25
+		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -267,6 +291,10 @@ LIGHTNINGBOAT:
 		Prerequisites: ~harbor.yi, techcenter
 		BuildPaletteOrder: 50
 		Description: actor-lightningboat.description
+	Encyclopedia:
+		Description: actor-lightningboat.encyclopedia
+		Order: 20
+		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -308,6 +336,10 @@ BOOMER:
 		Prerequisites: ~harbor.sc, techcenter
 		BuildPaletteOrder: 60
 		Description: actor-boomer.description
+	Encyclopedia:
+		Description: actor-boomer.encyclopedia
+		Order: 40
+		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -377,6 +409,10 @@ CARRIER:
 		BuildPaletteOrder: 60
 		Prerequisites: ~harbor.yi, techcenter
 		Description: actor-carrier.description
+	Encyclopedia:
+		Description: actor-carrier.encyclopedia
+		Order: 30
+		Category: Ships
 	Valued:
 		Cost: 2500
 	Tooltip:
@@ -432,6 +468,10 @@ FERRY:
 		Prerequisites: ~harbor
 		BuildPaletteOrder: 20
 		Description: actor-ferry.description
+	Encyclopedia:
+		Description: actor-ferry.encyclopedia
+		Order: 45
+		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -473,6 +513,10 @@ MINESHIP:
 		Prerequisites: ~harbor.sc, trader
 		BuildPaletteOrder: 40
 		Description: actor-mineship.description
+	Encyclopedia:
+		Description: actor-mineship.encyclopedia
+		Order: 50
+		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -525,3 +569,4 @@ MINESHIP2:
 	Inherits: MINESHIP
 	Buildable:
 		Prerequisites: ~harbor.yi, trader
+	-Encyclopedia:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -226,10 +226,6 @@ RADARTANK:
 		Cost: 400
 	Tooltip:
 		Name: actor-radartank.name
-		RequiresCondition: !deployed
-	Tooltip@DEPLOYED:
-		Name: actor-radartank.deployed--name
-		RequiresCondition: deployed
 	Selectable:
 		Class: radartank
 	Health:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -16,6 +16,10 @@ MBT:
 		Prerequisites: ~factory.yi
 		Queue: Tank
 		Description: actor-mbt.description
+	Encyclopedia:
+		Description: actor-mbt.encyclopedia
+		Order: 0
+		Category: Tanks
 	Mobile:
 		TurnSpeed: 25
 		Speed: 95
@@ -50,6 +54,7 @@ MBT2:
 	Inherits: MBT
 	Buildable:
 		Prerequisites: ~factory.sc
+	-Encyclopedia:
 	Turreted:
 		Offset: 0,0,0
 	Armament:
@@ -64,6 +69,10 @@ AATANK:
 		BuildPaletteOrder: 20
 		Prerequisites: ~factory.sc
 		Description: actor-aatank.description
+	Encyclopedia:
+		Description: actor-aatank.encyclopedia
+		Order: 6
+		Category: Tanks
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -102,7 +111,11 @@ AATANK2:
 	Inherits: AATANK
 	Buildable:
 		Prerequisites: ~factory.yi
-		Description: actor-aatank2-description
+		Description: actor-aatank2.description
+	Encyclopedia:
+		Description: actor-aatank2.encyclopedia
+		Order: 5
+		Category: Tanks
 	Armament:
 		Weapon: LightningBoltLight
 		Recoil: 125
@@ -123,6 +136,10 @@ APC:
 		Prerequisites: factory, module
 		BuildPaletteOrder: 40
 		Description: actor-apc.description
+	Encyclopedia:
+		Description: actor-apc.encyclopedia
+		Order: 10
+		Category: Tanks
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -180,6 +197,10 @@ ARTILLERY:
 		Prerequisites: factory, radar
 		BuildPaletteOrder: 50
 		Description: actor-artillery.description
+	Encyclopedia:
+		Description: actor-artillery.encyclopedia
+		Order: 15
+		Category: Tanks
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -222,6 +243,10 @@ RADARTANK:
 		BuildPaletteOrder: 40
 		Prerequisites: radar
 		Description: actor-radartank.description
+	Encyclopedia:
+		Description: actor-radartank.encyclopedia
+		Order: 0
+		Category: Utilities
 	Valued:
 		Cost: 400
 	Tooltip:
@@ -294,6 +319,10 @@ REPAIRTANK:
 		Prerequisites: trader
 		BuildPaletteOrder: 50
 		Description: actor-repairtank.description
+	Encyclopedia:
+		Description: actor-repairtank.encyclopedia
+		Order: 5
+		Category: Utilities
 	Armament:
 		Weapon: RepairBeam
 		Cursor: repair
@@ -332,6 +361,10 @@ MINELAYER:
 		BuildPaletteOrder: 60
 		Prerequisites: trader
 		Description: actor-minelayer.description
+	Encyclopedia:
+		Description: actor-minelayer.encyclopedia
+		Order: 10
+		Category: Utilities
 	Valued:
 		Cost: 700
 	Tooltip:
@@ -386,6 +419,10 @@ RAILGUNTANK:
 	Tooltip:
 		Name: actor-railguntank.name
 		GenericName: actor-railguntank.generic-name
+	Encyclopedia:
+		Description: actor-railguntank.encyclopedia
+		Order: 25
+		Category: Tanks
 	Selectable:
 		Class: railguntank
 	Buildable:
@@ -424,6 +461,10 @@ LIGHTNINGTANK:
 		BuildPaletteOrder: 70
 		Prerequisites: ~factory.yi, techcenter
 		Description: actor-lightningtank.description
+	Encyclopedia:
+		Description: actor-lightningtank.encyclopedia
+		Order: 20
+		Category: Tanks
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -464,6 +505,10 @@ STEALTHTANK:
 		BuildPaletteOrder: 80
 		Prerequisites: ~factory.yi, techcenter
 		Description: actor-stealthtank.description
+	Encyclopedia:
+		Description: actor-stealthtank.encyclopedia
+		Order: 30
+		Category: Tanks
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -523,6 +568,10 @@ MERCTANK:
 		Prerequisites: ~disabled
 		BuildPaletteOrder: 90
 		Description: actor-merctank.description
+	Encyclopedia:
+		Description: actor-merctank.encyclopedia
+		Order: 50
+		Category: Tanks
 	Armament:
 		Weapon: TankCannon
 		MuzzleSequence: muzzle
@@ -555,6 +604,7 @@ DUALMERCTANK:
 	Buildable:
 		BuildPaletteOrder: 90
 		Description: actor-dualmerctank-description
+	-Encyclopedia:
 	Selectable:
 		Class: dualmerctank
 	Armament:
@@ -582,6 +632,10 @@ ECMTANK:
 		Prerequisites: ~factory.sc, techcenter, trader
 		BuildPaletteOrder: 60
 		Description: actor-ecmtank.description
+	Encyclopedia:
+		Description: actor-ecmtank.encyclopedia
+		Order: 45
+		Category: Tanks
 	Armament:
 		Weapon: ElectronicCountermeasure
 	AttackFrontal:
@@ -630,6 +684,10 @@ DUALARTILLERY:
 		BuildPaletteOrder: 100
 		Prerequisites: ~disabled
 		Description: actor-dualartillery.description
+	Encyclopedia:
+		Description: actor-dualartillery.encyclopedia
+		Order: 55
+		Category: Tanks
 	Health:
 		HP: 35000
 	Armor:
@@ -670,6 +728,10 @@ BUILDER:
 		BuildPaletteOrder: 10
 		Description: actor-builder.description
 		Prerequisites: ~structures.yi
+	Encyclopedia:
+		Description: actor-builder.encyclopedia
+		Order: 15
+		Category: Utilities
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -715,6 +777,7 @@ BUILDER2:
 	Inherits: BUILDER
 	Buildable:
 		Prerequisites: ~structures.sc
+	-Encyclopedia:
 	Transforms:
 		IntoActor: outpost2
 	Selectable:
@@ -756,6 +819,10 @@ MINER:
 		BuildPaletteOrder: 20
 		Description: actor-miner.description
 		Prerequisites: storage
+	Encyclopedia:
+		Description: actor-miner.encyclopedia
+		Order: 20
+		Category: Utilities
 	Valued:
 		Cost: 1100
 	Tooltip:
@@ -815,6 +882,10 @@ MISSILETANK:
 		Prerequisites: ~factory.sc, radar, techcenter
 		BuildPaletteOrder: 80
 		Description: actor-missiletank.description
+	Encyclopedia:
+		Description: actor-missiletank.encyclopedia
+		Order: 35
+		Category: Tanks
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -848,6 +919,10 @@ HACKERTANK:
 		BuildPaletteOrder: 60
 		Prerequisites: ~factory.yi, radar, trader
 		Description: actor-hackertank.description
+	Encyclopedia:
+		Description: actor-hackertank.encyclopedia
+		Order: 40
+		Category: Tanks
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -909,6 +984,10 @@ BUGGY:
 		Prerequisites: module, ~factory.sc
 		Queue: Tank
 		Description: actor-buggy.description
+	Encyclopedia:
+		Description: actor-buggy.encyclopedia
+		Order: 7
+		Category: Tanks
 	Turreted:
 		TurnSpeed: 40
 		Offset: 0,0,150
@@ -952,6 +1031,10 @@ BIKE:
 		Prerequisites: module, ~factory.yi
 		BuildPaletteOrder: 30
 		Description: actor-bike.description
+	Encyclopedia:
+		Description: actor-bike.encyclopedia
+		Order: 6
+		Category: Tanks
 	AttackFrontal:
 		PauseOnCondition: jammed
 		Voice: Attack
@@ -1014,6 +1097,10 @@ TANKER2:
 	Inherits: TANKER1
 	Buildable:
 		Description: actor-tanker2.description
+	Encyclopedia:
+		Description: actor-tanker2.encyclopedia
+		Order: 30
+		Category: Utilities
 	Tooltip:
 		Name: actor-tanker2.name
 	-SpawnScrapOnDeath:
@@ -1030,6 +1117,10 @@ CVIT:
 		BuildPaletteOrder: 30
 		Prerequisites: storage
 		Description: actor-cvit.description
+	Encyclopedia:
+		Description: actor-cvit.encyclopedia
+		Order: 25
+		Category: Utilities
 	Valued:
 		Cost: 500
 	Tooltip:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -235,8 +235,8 @@ RADARTANK:
 	Mobile:
 		Speed: 90
 		TurnSpeed: 20
-		ImmovableCondition: !undeployed
-		RequireForceMoveCondition: !undeployed
+		ImmovableCondition: deployed
+		RequireForceMoveCondition: deployed
 	RevealsShroud:
 		RequiresCondition: undeployed
 		Range: 8c0
@@ -246,7 +246,7 @@ RADARTANK:
 		Range: 4c0
 		RequiresCondition: undeployed
 	RevealsShroud@DEPLOYED:
-		RequiresCondition: !undeployed
+		RequiresCondition: deployed
 		Range: 14c0
 	WithMakeAnimation:
 		Sequence: extend
@@ -261,9 +261,9 @@ RADARTANK:
 		AllowedTerrainTypes: Clear, Road, Crater, Grass, Grass Ramp, Grass Pit, Ore, Mountain, Mountain Ramp, Rock, Ice, Snow, Snow Ramp, Sand, Sand Ramp, Stone, Tech, Dirt
 		Voice: Move
 	Repairable:
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: deployed
 	WithSpriteBody@DEPLOYED:
-		RequiresCondition: !undeployed
+		RequiresCondition: deployed
 		Sequence: extended
 		Name: deployed
 	RenderDetectionCircle:
@@ -276,7 +276,7 @@ RADARTANK:
 		DetectionTypes: Cloak, Underwater
 	DetectCloaked@Deployed:
 		Range: 14c0
-		RequiresCondition: !jammed && !undeployed
+		RequiresCondition: !jammed && deployed
 		DetectionTypes: Cloak, Underwater
 
 REPAIRTANK:


### PR DESCRIPTION
* Added a new `Pods` label
* Added a new `Tanks` label
* Added a new `Utilities` label
* Added a new `Aircraft` label
* Added a new `Ships` label
* Removed Radar Tank's deployed-only tooltip
* Use `deployed` condition instead of `!undeployed` across the rules
* Fixed some encountered unit descriptions
* Updated flamer pod's tooltip to Flamer (old was Flame)
* Updated apc's tooltip to APC (old was Transport Tank)