### PR TITLE
Made Bomber jet non-repulsable

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -643,7 +643,7 @@ BOMBER:
 	Aircraft:
 		TurnSpeed: 360
 		Speed: 450
-		Repulsable: True
+		Repulsable: false
 		Voice: Move
 	RejectsOrders:
 	AttackBomber:


### PR DESCRIPTION
This fixes the issue where bombers have a weird visual when colliding with other aircraft or the map's borders.