### PR TITLE
Increase Battleship HP

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -825,7 +825,7 @@ BATTLESHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 250000
+		HP: 375000
 	Armor:
 		Type: Heavy
 	RevealsShroud:


### PR DESCRIPTION
It increases its HP by 50% compared to Mothership. Trying to think now for when we have AA Air in near future (hopefully).