### PR TITLE
Added range circles to Nuke and Railgun support powers

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -1506,6 +1506,8 @@ SILO:
 		SelectTargetTextNotification: notification-select-target
 		IncomingSpeechNotification: NukeIncoming
 		OrderName: Nukem
+		CircleRanges: 9c0
+		CircleColor: FFFFFF
 	SupportPowerChargeBar:
 	Power:
 		Amount: -150
@@ -1588,6 +1590,7 @@ UPLINK:
 		SelectTargetTextNotification: notification-select-target
 		IncomingSpeechNotification: OrbitalRailgunFired
 		AirburstAltitude: 40c0
+		TargetCircleRange: 3c0
 		Weapon: RailgunSetup
 
 STORAGE:


### PR DESCRIPTION
Added a range circle to both Nuke and Railgun support powers, to show the damage range to the player.