### PR TITLE
Give the watchtower more visibility

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -2595,21 +2595,21 @@ WATCHTOWER:
 			TopLeft: -1024, 0
 			BottomRight: 1024, 1024
 	RevealsShroud:
-		Range: 6c0
-		MinRange: 3c0
+		Range: 8c0
+		MinRange: 4c0
 		RevealGeneratedShroud: false
 		RequiresCondition: !disabled && !ownerless && !boosted
 	RevealsShroud@Boosted:
-		Range: 12c0
-		MinRange: 3c0
+		Range: 16c0
+		MinRange: 8c0
 		RevealGeneratedShroud: false
 		RequiresCondition: !disabled && !ownerless && boosted
 	RevealsShroud@Offline:
-		Range: 10c0
+		Range: 12c0
 		RevealGeneratedShroud: false
 		RequiresCondition: disabled && !ownerless
 	RevealsShroud@Hacked:
-		Range: 7c0
+		Range: 8c0
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	GrantConditionOnNeutralOwner:


### PR DESCRIPTION
I gave the watchtower a greater visibility (now 16 instead of 12), to make placing units there more important, especially in strategic points. It has almost the same range of the hot air balloon.