### PR TITLE
Increase Combat Units Cost and Tweak AI

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -15,7 +15,7 @@ GUNSHIP:
 		Order: 2
 		Category: Aircraft
 	Valued:
-		Cost: 1000
+		Cost: 2000
 	Tooltip:
 		Name: actor-gunship.name
 	UpdatesPlayerStatistics:
@@ -80,7 +80,7 @@ JET:
 		Order: 10
 		Category: Aircraft
 	Valued:
-		Cost: 1500
+		Cost: 3000
 	Tooltip:
 		Name: actor-jet.name
 	UpdatesPlayerStatistics:
@@ -145,7 +145,7 @@ COPTER:
 	Inherits@MagazineCasing: ^DropShellCasing
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 1000
+		Cost: 2000
 	Tooltip:
 		Name: actor-copter.name
 	Buildable:
@@ -194,7 +194,7 @@ COPTER:
 SAUCER:
 	Inherits: ^Helicopter
 	Valued:
-		Cost: 400
+		Cost: 800
 	Tooltip:
 		Name: actor-saucer.name
 	Buildable:
@@ -238,7 +238,7 @@ BANSHEE:
 	Inherits@Smoke: ^SmokeEmitter
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1500
+		Cost: 3000
 	Tooltip:
 		Name: actor-banshee.name
 	Buildable:
@@ -294,7 +294,7 @@ CHOPPER:
 	Inherits: ^Helicopter
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 900
+		Cost: 1800
 	Tooltip:
 		Name: actor-chopper.name
 	Buildable:
@@ -390,7 +390,7 @@ CHOPPER.Husk:
 BALLOON:
 	Inherits: ^Helicopter
 	Valued:
-		Cost: 400
+		Cost: 800
 	Tooltip:
 		Name: actor-balloon.name
 	Buildable:
@@ -436,7 +436,7 @@ DROPSHIP:
 	Inherits: ^Helicopter
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 900
+		Cost: 1800
 	Tooltip:
 		Name: actor-dropship.name
 	Buildable:
@@ -535,7 +535,7 @@ DROPSHIP.Husk:
 DRONE:
 	Inherits: ^SpawnedPlane
 	Valued:
-		Cost: 50
+		Cost: 100
 	Tooltip:
 		Name: actor-drone-name
 	Health:
@@ -575,7 +575,7 @@ DRONE:
 DRONE2:
 	Inherits: ^SpawnedPlane
 	Valued:
-		Cost: 50
+		Cost: 100
 	Tooltip:
 		Name: actor-drone2.name
 	Health:
@@ -673,7 +673,7 @@ BOMBER:
 	Armor:
 		Type: Light
 	Valued:
-		Cost: 2000
+		Cost: 4000
 	UpdatesPlayerStatistics:
 		AddToAssetsValue: false
 	Aircraft:
@@ -703,7 +703,7 @@ CARGOSHIP:
 	Tooltip:
 		Name: actor-cargoship-name
 	Valued:
-		Cost: 2000
+		Cost: 4000
 	WithLandingUnloadAnimation:
 
 AIRLIFTER:
@@ -722,14 +722,14 @@ AIRLIFTER:
 	Tooltip:
 		Name: actor-airlifter-name
 	Valued:
-		Cost: 2000
+		Cost: 4000
 
 MOTHERSHIP:
 	Inherits: ^Helicopter
 	Inherits@Smoke: ^SmokeEmitter
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 6000
+		Cost: 12000
 	Tooltip:
 		Name: actor-mothership.name
 	Buildable:
@@ -861,7 +861,7 @@ BATTLESHIP:
 	Inherits@Smoke: ^SmokeEmitter
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 6000
+		Cost: 12000
 	Tooltip:
 		Name: actor-battleship.name
 	Buildable:

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -16,9 +16,11 @@ Player:
 	BaseBuilderBotModule@RogueAI:
 		RequiresCondition: enable-rogue-ai
 		MinimumExcessPower: 40
-		MaximumExcessPower: 200
-		AdditionalMinimumRefineryCount: 0
-		NewProductionCashThreshold: 10000
+		MaximumExcessPower: 500
+		InititalMinimumRefineryCount: 1
+		AdditionalMinimumRefineryCount: 1
+		PlaceDefenseTowardsEnemyChance: 0
+		NewProductionCashThreshold: 7000
 		WaterTerrainTypes: Littoral
 		ConstructionYardTypes: base, base2
 		PowerTypes: generator
@@ -30,7 +32,7 @@ Player:
 		DefenseTypes: turret, turret2, aaturret, aaturret2, bunker, bunker2
 		BuildingLimits:
 			base: 1
-			storage: 1
+			storage: 3
 			module: 4
 			module2: 4
 			factory: 4
@@ -39,8 +41,8 @@ Player:
 			radar2: 1
 			starport: 4
 			starport2: 4
-			oresmelt: 4
-			orepurifier: 4
+			oresmelt: 2
+			orepurifier: 2
 			trader: 1
 			techcenter: 1
 			harbor: 1
@@ -49,9 +51,11 @@ Player:
 			howitzer: 1
 			uplink: 1
 			silo: 1
+			outpost: 2
+			outpost2: 2
 		BuildingFractions:
 			base: 1
-			storage: 2
+			storage: 1
 			module: 1
 			module2: 1
 			radar: 1
@@ -64,31 +68,39 @@ Player:
 			starport: 1
 			starport2: 1
 			techcenter: 1
-			oresmelt: 9
-			orepurifier: 9
-			bunker: 7
-			bunker2: 7
-			turret: 5
-			turret2: 5
-			aaturret: 6
-			aaturret2: 6
+			oresmelt: 20
+			orepurifier: 20
+			bunker: 12
+			bunker2: 12
+			turret: 12
+			turret2: 12
+			aaturret: 12
+			aaturret2: 12
 			howitzer: 1
 			uplink: 1
 			field: 1
 			silo: 1
 		BuildingDelays:
-			radar: 4000
-			radar2: 4000
-			howitzer: 8000
-			field: 8000
-			silo: 9000
-			uplink: 9000
+			bunker: 150
+			bunker2: 150
+			aaturret: 150
+			aaturret2: 150
+			turret: 150
+			turret2: 150
+			radar: 10000
+			radar2: 10000
+			factory: 11000
+			factory2: 11000
+			howitzer: 12000
+			field: 12000
+			silo: 13000
+			uplink: 13000
 	BuildingRepairBotModule:
 		RequiresCondition: enable-rogue-ai
 	SquadManagerBotModule@RogueAI:
 		RequiresCondition: enable-rogue-ai
 		SquadSize: 20
-		ExcludeFromSquadsTypes: miner, builder, builder2, tanker1, tanker2, minelayer, ecmtank, technician, broker, mineship, mineship2, blaster
+		ExcludeFromSquadsTypes: miner, builder, builder2, tanker1, tanker2, minelayer, technician, broker, mineship, mineship2, blaster
 		NavalUnitsTypes: torpedoboat, railgunboat, lightboat, patrolboat, boomer, submarine, carrier
 		AirUnitsTypes: gunship, jet, copter, banshee
 		ConstructionYardTypes: base, base2
@@ -96,7 +108,7 @@ Player:
 	UnitBuilderBotModule@RogueAI:
 		IdleBaseUnitsMaximum: 30
 		RequiresCondition: enable-rogue-ai
-		UnitQueues: Pod, Utility, Tank, Aircraft, Ship
+		UnitQueues: Pod, Utility, Tank, Aircraft, Ship, Trade
 		UnitsToBuild:
 			miner: 3
 			builder: 1
@@ -105,23 +117,27 @@ Player:
 			buggy: 3
 			bike: 3
 			mbt: 5
+			mbt2: 5
 			railguntank: 5
+			lightningtank: 5
 			minelayer: 1
-			stealthtank: 1
+			stealthtank: 5
+			aatank: 4
+			aatank2: 4
 			ecmtank: 1
-			aatank: 3
 			hackertank: 1
 			repairtank: 1
 			apc: 1
+			apc2: 1
 			artillery: 5
 			rifleman: 1
 			rocketeer: 1
 			mortar: 1
-			flamer: 1
 			jetpacker: 1
 			sniper: 1
 			shocker: 1
 			technician: 1
+			flamer: 1
 			blaster: 1
 			missiletank: 5
 			jet: 5
@@ -130,9 +146,10 @@ Player:
 			banshee: 5
 			balloon: 1
 			saucer: 1
-			torpedoboat: 1
-			railgunboat: 1
-			lightboat: 1
+			torpedoboat: 2
+			lightboat: 2
+			railgunboat: 2
+			lightningboat: 2
 			boomer: 2
 			carrier: 2
 			mineship: 1
@@ -140,15 +157,14 @@ Player:
 			battleship: 1
 			mothership: 1
 		UnitLimits:
-			miner: 1
+			miner: 2
 			builder: 1
 			builder2: 1
 			balloon: 2
 			saucer: 2
-			radartank: 1
+			radartank: 2
 			minelayer: 1
-			ecmtank: 1
-			lightboat: 3
+			flamer: 3
 			boomer: 4
 			carrier: 4
 			mineship: 1
@@ -156,9 +172,10 @@ Player:
 			technician: 1
 			blaster: 3
 			apc: 1
+			apc2: 1
 		UnitDelays:
-			builder: 15000
-			builder2: 15000
+			builder: 7500
+			builder2: 7500
 	PriorityCaptureManagerBotModule:
 		RequiresCondition: enable-rogue-ai
 		CapturingActorTypes: technician

--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -13,7 +13,7 @@ RIFLEMAN:
 		Order: 0
 		Category: Pods
 	Valued:
-		Cost: 100
+		Cost: 200
 	Tooltip:
 		Name: actor-rifleman.name
 	UpdatesPlayerStatistics:
@@ -53,7 +53,7 @@ ROCKETEER:
 		Order: 10
 		Category: Pods
 	Valued:
-		Cost: 225
+		Cost: 450
 	Tooltip:
 		Name: actor-rocketeer.name
 	UpdatesPlayerStatistics:
@@ -91,7 +91,7 @@ MORTAR:
 		Order: 35
 		Category: Pods
 	Valued:
-		Cost: 150
+		Cost: 300
 	Tooltip:
 		Name: actor-mortar.name
 	UpdatesPlayerStatistics:
@@ -131,7 +131,7 @@ SNIPER:
 		Order: 30
 		Category: Pods
 	Valued:
-		Cost: 500
+		Cost: 1000
 	Tooltip:
 		Name: actor-sniper.name
 	UpdatesPlayerStatistics:
@@ -182,7 +182,7 @@ FLAMER:
 		Order: 25
 		Category: Pods
 	Valued:
-		Cost: 350
+		Cost: 700
 	Tooltip:
 		Name: actor-flamer.name
 	UpdatesPlayerStatistics:
@@ -223,7 +223,7 @@ TECHNICIAN:
 		Order: 15
 		Category: Pods
 	Valued:
-		Cost: 500
+		Cost: 1000
 	Tooltip:
 		Name: actor-technician.name
 	UpdatesPlayerStatistics:
@@ -283,7 +283,7 @@ BROKER:
 		Order: 16
 		Category: Pods
 	Valued:
-		Cost: 700
+		Cost: 1400
 	Tooltip:
 		Name: actor-broker.name
 	UpdatesPlayerStatistics:
@@ -337,7 +337,7 @@ JETPACKER:
 		Order: 40
 		Category: Pods
 	Valued:
-		Cost: 650
+		Cost: 1300
 	Tooltip:
 		Name: actor-jetpacker.name
 	Health:
@@ -384,7 +384,7 @@ BLASTER:
 		Order: 20
 		Category: Pods
 	Valued:
-		Cost: 600
+		Cost: 1200
 	Tooltip:
 		Name: actor-blaster.name
 	Health:
@@ -440,7 +440,7 @@ SHOCKER:
 		Order: 5
 		Category: Pods
 	Valued:
-		Cost: 225
+		Cost: 450
 	Tooltip:
 		Name: actor-shocker.name
 	Voiced:

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -4,7 +4,7 @@ LIGHTBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 450
+		Cost: 900
 	Tooltip:
 		Name: actor-lightboat.name
 		GenericName: actor-lightboat.generic-name
@@ -52,7 +52,7 @@ PATROLBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 450
+		Cost: 900
 	Tooltip:
 		Name: actor-patrolboat.name
 		GenericName: actor-patrolboat.generic-name
@@ -105,7 +105,7 @@ MERCBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 1600
 	Tooltip:
 		Name: actor-mercboat.name
 		GenericName: actor-mercboat.generic-name
@@ -151,7 +151,7 @@ TORPEDOBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 1600
 	Tooltip:
 		Name: actor-torpedoboat.name
 		GenericName: actor-torpedoboat.generic-name
@@ -194,7 +194,7 @@ SUBMARINE:
 	Inherits: ^Submarine
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 1600
 	Tooltip:
 		Name: actor-submarine.name
 		GenericName: actor-submarine.generic-name
@@ -237,7 +237,7 @@ RAILGUNBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 2000
+		Cost: 4000
 	Tooltip:
 		Name: actor-railgunboat.name
 		GenericName: actor-railgunboat.generic-name
@@ -281,7 +281,7 @@ LIGHTNINGBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 2000
+		Cost: 4000
 	Tooltip:
 		Name: actor-lightningboat.name
 		GenericName: actor-lightningboat.generic-name
@@ -326,7 +326,7 @@ BOOMER:
 	Inherits: ^Submarine
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 2500
+		Cost: 5000
 	Tooltip:
 		Name: actor-boomer.name
 		GenericName: actor-boomer.generic-name
@@ -377,7 +377,7 @@ BOOMER:
 SLCM:
 	Inherits: ^ShootableMissile
 	Valued:
-		Cost: 50
+		Cost: 100
 	Tooltip:
 		Name: actor-slcm-name
 	Health:
@@ -416,7 +416,7 @@ CARRIER:
 		Order: 30
 		Category: Ships
 	Valued:
-		Cost: 2500
+		Cost: 5000
 	Tooltip:
 		Name: actor-carrier.name
 	Health:
@@ -460,7 +460,7 @@ CARRIER:
 FERRY:
 	Inherits: ^Ship
 	Valued:
-		Cost: 700
+		Cost: 1400
 	Tooltip:
 		Name: actor-ferry.name
 		GenericName: actor-ferry.generic-name
@@ -505,7 +505,7 @@ MINESHIP:
 	Inherits: ^Ship
 	Inherits@Selection: ^SelectableSupportUnit
 	Valued:
-		Cost: 700
+		Cost: 1400
 	Tooltip:
 		Name: actor-mineship.name
 		GenericName: actor-mineship.generic-name

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -4,7 +4,7 @@ MBT:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 850
+		Cost: 1700
 	Tooltip:
 		Name: actor-mbt.name
 	Selectable:
@@ -74,7 +74,7 @@ AATANK:
 		Order: 6
 		Category: Tanks
 	Valued:
-		Cost: 500
+		Cost: 1000
 	Tooltip:
 		Name: actor-aatank.name
 	Selectable:
@@ -128,7 +128,7 @@ APC:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 600
+		Cost: 1200
 	Tooltip:
 		Name: actor-apc.name
 	Buildable:
@@ -187,7 +187,7 @@ ARTILLERY:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 1600
 	Tooltip:
 		Name: actor-artillery.name
 	Selectable:
@@ -248,7 +248,7 @@ RADARTANK:
 		Order: 0
 		Category: Utilities
 	Valued:
-		Cost: 400
+		Cost: 800
 	Tooltip:
 		Name: actor-radartank.name
 	Selectable:
@@ -308,7 +308,7 @@ REPAIRTANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 1600
 	Tooltip:
 		Name: actor-repairtank.name
 		GenericName: actor-repairtank.generic-name
@@ -366,7 +366,7 @@ MINELAYER:
 		Order: 10
 		Category: Utilities
 	Valued:
-		Cost: 700
+		Cost: 1400
 	Tooltip:
 		Name: actor-minelayer.name
 	Selectable:
@@ -415,7 +415,7 @@ RAILGUNTANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1500
+		Cost: 3000
 	Tooltip:
 		Name: actor-railguntank.name
 		GenericName: actor-railguntank.generic-name
@@ -466,7 +466,7 @@ LIGHTNINGTANK:
 		Order: 20
 		Category: Tanks
 	Valued:
-		Cost: 1500
+		Cost: 3000
 	Tooltip:
 		Name: actor-lightningtank.name
 		GenericName: actor-lightningtank.generic-name
@@ -510,7 +510,7 @@ STEALTHTANK:
 		Order: 30
 		Category: Tanks
 	Valued:
-		Cost: 1200
+		Cost: 2400
 	Tooltip:
 		Name: actor-stealthtank.name
 	Selectable:
@@ -557,7 +557,7 @@ MERCTANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 850
+		Cost: 1700
 	Tooltip:
 		Name: actor-merctank.name
 		GenericName: actor-merctank.generic-name
@@ -621,7 +621,7 @@ DUALMERCTANK:
 ECMTANK:
 	Inherits: ^TrackedVehicle
 	Valued:
-		Cost: 1000
+		Cost: 2000
 	Tooltip:
 		Name: actor-ecmtank.name
 		GenericName: actor-ecmtank.generic-name
@@ -672,7 +672,7 @@ DUALARTILLERY:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1750
+		Cost: 3500
 	Tooltip:
 		Name: actor-dualartillery.name
 	Selectable:
@@ -871,7 +871,7 @@ MISSILETANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1200
+		Cost: 2400
 	Tooltip:
 		Name: actor-missiletank.name
 		GenericName: actor-missiletank.generic-name
@@ -924,7 +924,7 @@ HACKERTANK:
 		Order: 40
 		Category: Tanks
 	Valued:
-		Cost: 1000
+		Cost: 2000
 	Tooltip:
 		Name: actor-hackertank.name
 	Selectable:
@@ -973,7 +973,7 @@ BUGGY:
 	Inherits: ^Vehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 400
+		Cost: 800
 	Tooltip:
 		Name: actor-buggy.name
 		GenericName: actor-buggy.generic-name
@@ -1020,7 +1020,7 @@ BIKE:
 	Inherits: ^Vehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 400
+		Cost: 800
 	Tooltip:
 		Name: actor-bike.name
 		GenericName: actor-bike.generic-name
@@ -1067,7 +1067,7 @@ TANKER1:
 		Prerequisites: ~disabled
 		Description: actor-tanker1.description
 	Valued:
-		Cost: 500
+		Cost: 1000
 	Tooltip:
 		Name: actor-tanker1.name
 	Selectable:


### PR DESCRIPTION
Motivations:

- Aids on performance issues when there's a lot of units in the match
- By reducing the combat units amount, it's easier to micro, being a little more important for the game
- Tweak AI with the new cost changes and some other changes like building at least 2 Storages so it's harder to kill it

The cost increase proportion is +100%. Units not affected are: Miner, Builders, Recon Tank, Money Transport