### PR TITLE
Allow ships to capture watchtowers and flagposts, and planes flagposts

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -2636,6 +2636,7 @@ WATCHTOWER:
 	-CaptureNotification:
 	ProximityCapturable:
 		Sticky: true
+  		CaptorTypes: Vehicle, Ship
 
 DROPZONE:
 	Inherits: ^Building
@@ -2731,6 +2732,7 @@ FLAGPOST:
 	-CapturableProgressBeep:
 	-CaptureManager:
 	ProximityCapturable:
+  		CaptorTypes: Vehicle, Ship, Plane
 	StrategicPoint:
 	GrantConditionOnNeutralOwner:
 		Condition: ownerless


### PR DESCRIPTION
Fixes #1174.

* Allowed the ships to capture both watchtowers and flagposts
* Allowed planes (any aircraft) to capture flagposts (but not watchtowers)