### PR TITLE
Change Planes and Speeders movement pattern and basic air weaponry

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -167,12 +167,12 @@ COPTER:
 	Health:
 		HP: 10000
 	RevealsShroud:
-		Range: 10c0
-		MinRange: 4c0
+		Range: 12c0
+		MinRange: 6c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
 		TurnSpeed: 20

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -30,16 +30,12 @@ GUNSHIP:
 	RevealsShroud@Hacked:
 		Range: 4c0
 		Type: GroundPosition
-	Armament@Ground:
+	Armament:
 		Weapon: AircraftChainGunGround
 		MuzzleSequence: muzzle
 		LocalOffset: 300,0,0
-	Armament@Air:
-		Weapon: AircraftChainGunAir
-		MuzzleSequence: muzzle
-		LocalOffset: 300,0,0
 	AttackAircraft:
-		FacingTolerance: 92
+		FacingTolerance: 32
 		PersistentTargeting: false
 		OpportunityFire: false
 	Aircraft:
@@ -138,6 +134,15 @@ JET:
 		Offset: -298,164,0
 		TrailLength: 12
 		ZOffset: -1000
+	Cloak:
+		InitialDelay: 250
+		CloakDelay: 120
+		CloakSound:
+		UncloakSound:
+		UncloakOn: Attack, Unload
+		IsPlayerPalette: true
+		CloakedPalette: cloak
+		CloakStyle: Palette
 
 COPTER:
 	Inherits: ^Helicopter
@@ -179,12 +184,8 @@ COPTER:
 		Offset: 200,0,-100
 	AttackTurreted:
 		RequiresCondition: airborne
-	Armament@Ground:
+	Armament:
 		Weapon: HelicopterChainGunGround
-		MuzzleSequence: muzzle
-		LocalOffset: 50,0,0
-	Armament@Air:
-		Weapon: HelicopterChainGunAir
 		MuzzleSequence: muzzle
 		LocalOffset: 50,0,0
 	Selectable:
@@ -533,23 +534,11 @@ DROPSHIP.Husk:
 		Image: dropship
 
 DRONE:
-	Inherits: ^SpawnedPlane
-	Valued:
-		Cost: 100
+	Inherits: ^BaseDrone
 	Tooltip:
 		Name: actor-drone-name
 	Health:
 		HP: 5000
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 4c0
-		MinRange: 2c0
-		Type: GroundPosition
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 2c0
-		Type: GroundPosition
 	Armament:
 		Weapon: DroneBlaster
 		PauseOnCondition: !ammo
@@ -557,39 +546,22 @@ DRONE:
 		Sequence: shoot
 	Aircraft:
 		Speed: 250
-		AltitudeVelocity: 240
-		VTOL: true
-		Repulsable: false
 	AttackAircraft:
 		FacingTolerance: 92
 		Voice: Attack
 	AmmoPool:
 		Ammo: 5
-		AmmoCondition: ammo
 	CarrierChild:
 		LandingDistance: 8c0
 	Rearmable:
 		RearmActors: carrier
-	-MapEditorData:
 
 DRONE2:
-	Inherits: ^SpawnedPlane
-	Valued:
-		Cost: 100
+	Inherits: ^BaseDrone
 	Tooltip:
 		Name: actor-drone2.name
 	Health:
 		HP: 7500
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 4c0
-		MinRange: 2c0
-		Type: GroundPosition
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 2c0
-		Type: GroundPosition
 	Armament:
 		Weapon: DronePulseGun
 		MuzzleSequence: muzzle
@@ -597,22 +569,17 @@ DRONE2:
 		PauseOnCondition: !ammo
 	Aircraft:
 		Speed: 200
-		AltitudeVelocity: 240
-		VTOL: true
-		Repulsable: false
 	AttackAircraft:
 		FacingTolerance: 256
 		Voice: Attack
 	AmmoPool:
 		Ammo: 250
 		ReloadCount: 15
-		AmmoCondition: ammo
 	CarrierChild:
 		LandingDistance: 16c0
 	Rearmable:
 		RearmActors: mothership
 	WithMuzzleOverlay:
-	-MapEditorData:
 
 DROPPOD1:
 	Inherits: ^DropPod

--- a/mods/hv/rules/animals.yaml
+++ b/mods/hv/rules/animals.yaml
@@ -48,7 +48,7 @@ BEAST:
 	-ProximityCaptor:
 
 CROW:
-	Inherits: ^Plane
+	Inherits: ^AirCreature
 	Valued:
 		Cost: 10
 	Health:
@@ -68,15 +68,6 @@ CROW:
 	WithShadow:
 		Offset: 200, 128, 0
 		ZOffset: -129
-	-Repairable:
-	-AppearsOnRadar:
-	-Selectable:
-	Interactable:
-	-Targetable@Airborne:
-	-ChangesHealth@Reconstructor:
-	-WithDecoration@Reconstructor:
-	-GrantConditionOnPrerequisite@Reconstructor:
-	-ProximityCaptor:
 
 CROW2:
 	Inherits: CROW
@@ -160,7 +151,7 @@ WORM:
 	DeathSounds:
 
 FLYINGMONSTER:
-	Inherits: ^Plane
+	Inherits: ^AirCreature
 	Valued:
 		Cost: 10
 	Health:
@@ -184,16 +175,3 @@ FLYINGMONSTER:
 		DeathPaletteIsPlayerPalette: false
 	Voiced:
 		VoiceSet: FlyingMonsterVoice
-	DeathSounds:
-	-Guard:
-	-Repairable:
-	-MustBeDestroyed:
-	-Explodes:
-	-Explodes@SpawnPilot:
-	-GrantRandomCondition@SpawnPilot:
-	-ChangesHealth@Reconstructor:
-	-WithDecoration@Reconstructor:
-	-GrantConditionOnPrerequisite@Reconstructor:
-	-Selectable:
-	Interactable:
-	-ProximityCaptor:

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -287,6 +287,8 @@
 		InitialFacing: 768
 		Voice: Move
 		TakeOffOnResupply: true
+		CanHover: True
+		WaitDistanceFromResupplyBase: 4c0
 	Targetable@Ground:
 		RequiresCondition: !airborne
 		TargetTypes: Ground, Vehicle
@@ -327,6 +329,26 @@
 		EmptyWeapon: PilotSpawn
 		RequiresCondition: spawn-pilot && !dont-spawn-pilot
 
+^AirCreature:
+	Inherits: ^Plane
+	Aircraft:
+		-AirborneCondition:
+	DeathSounds:
+	-AppearsOnRadar:
+	-Guard:
+	-Repairable:
+	-MustBeDestroyed:
+	-Explodes:
+	-Explodes@SpawnPilot:
+	-Targetable@Airborne:
+	-GrantRandomCondition@SpawnPilot:
+	-ChangesHealth@Reconstructor:
+	-WithDecoration@Reconstructor:
+	-GrantConditionOnPrerequisite@Reconstructor:
+	-Selectable:
+	Interactable:
+	-ProximityCaptor:
+
 ^PlaneHusk:
 	Inherits@Husk: ^Husk
 	Inherits@Sprite: ^SpriteActor
@@ -359,6 +381,34 @@
 	Aircraft:
 		IdleBehavior: None
 		Repulsable: False
+
+^BaseDrone:
+	Inherits: ^SpawnedPlane
+	Valued:
+		Cost: 100
+	Armor:
+		Type: Light
+	RevealsShroud:
+		Range: 4c0
+		MinRange: 2c0
+		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 2c0
+		Type: GroundPosition
+	Aircraft:
+		TurnSpeed: 60
+		AltitudeVelocity: 240
+		VTOL: true
+		Repulsable: false
+		AirborneCondition: airborne
+		CanHover: False
+	# 	-CruisingCondition:
+	# -Hovers@Cruising:
+	# 	-RequiresCondition:
+	AmmoPool:
+		AmmoCondition: ammo
+	-MapEditorData:
 
 ^CargoPlane:
 	Inherits@Exists: ^ExistsInWorld
@@ -440,6 +490,7 @@
 		GenericName: meta-helicopter-generic-name
 	Aircraft:
 		CanHover: true
+		AirborneCondition: airborne
 		CruisingCondition: cruising
 		WaitDistanceFromResupplyBase: 4c0
 		VTOL: true

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -137,7 +137,7 @@ Plasma:
 		Chance: 25
 		InvalidTargets: Vehicle, Structure
 	Warhead@Damage: SpreadDamage
-		Damage: 1750
+		Damage: 1325
 		Versus:
 			None: 43
 			Steel: 85

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -130,7 +130,7 @@ BikeChainGun:
 
 HelicopterChainGunGround:
 	Inherits: ^AircraftChainGun
-	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	ValidTargets: Water, Ground, Tree, Lava, Swamp, Air
 	ReloadDelay: 10
 	Range: 6c0
 	MinRange: 0c768
@@ -158,15 +158,16 @@ HelicopterChainGunAir:
 
 AircraftChainGunGround:
 	Inherits: ^AircraftChainGun
-	ValidTargets: Water, Ground, Tree, Lava, Swamp
-	ReloadDelay: 3
+	ValidTargets: Water, Ground, Tree, Lava, Swamp, Air
+	ReloadDelay: 6
 	Range: 6c0
 	MinRange: 1c0
 	Burst: 16
 	Projectile: InstantHit
 		Blockable: false
 	Warhead@Damage: SpreadDamage
-		Damage: 375
+		# ALMOST: Damage: 124
+		Damage: 120 # 124 # 125 # 124 # 132 # 113 # 124 # 141 # 150 # 188  # 125 # 188 # 375
 		Versus:
 			None: 800
 			Steel: 108


### PR DESCRIPTION
Motivation:

- Makes Yuruki's planes more useful in late game masses (since they expose themselves too much while engaging and it's very hard to micro them properly, specially with lag)
- Unifies both Helicopter and Plane's anti-air and anti-ground weapons
- Rebalances slightly Speeders and Planes (so they have roughly the same DPS as Banshees and Helicopters like before)