### PR TITLE
Make Force Field affect buildings

### DIFF
--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -508,6 +508,7 @@
 	Inherits@Exists: ^ExistsInWorld
 	Inherits@Sprite: ^SpriteActor
 	Inherits@Decoration: ^SelectionDecorations
+	Inherits@Shield: ^ForceFieldCompatible
 	Huntable:
 	OwnerLostAction:
 		Action: Kill


### PR DESCRIPTION
Motivation:

- Gives an option for Yuruki players to counter Howitzer attacks, specially if it's aimed at critical buildings like Mining Towers
- Gives an option to protect against snipes of important buildings like Storages and Main Bases