### PR TITLE
Switched Yuruki and Synapol factions

### DIFF
--- a/mods/hv/languages/rules/en.ftl
+++ b/mods/hv/languages/rules/en.ftl
@@ -24,31 +24,6 @@ faction-yuruki =
     an aggressive expansion throughout the solar system.
 
     Faction Variations:
-        - Uses fighter jets as air units
-
-    Special Units:
-        - Shocker Pod
-        - Blaster Pod
-        - Sniper Pod
-        - Gatling Bike
-        - Hacker Tank
-        - Lightning Tank
-        - Stealth Tank
-        - Battleship
-
-    Superweapon:
-        - Air Strike
-        - Field Generator
-        - Orbital Railgun Strike
-
-faction-synapol =
-   .name = Synapol
-   .description = Synapol Corporation
-    A large interplanetary company that manufactures
-    everything from common household appliances to armaments.
-    Their security department became a large paramilitary force.
-
-    Faction Variations:
         - Uses helicopters as air units
         - Uses submarines as advanced naval units
 
@@ -66,6 +41,31 @@ faction-synapol =
         - Drop Pods
         - Grand Howitzer
         - Thermonuclear Bomb
+
+faction-synapol =
+   .name = Synapol
+   .description = Synapol Corporation
+    A large interplanetary company that manufactures
+    everything from common household appliances to armaments.
+    Their security department became a large paramilitary force.
+
+    Faction Variations:
+        - Uses fighter jets as air units
+
+    Special Units:
+        - Shocker Pod
+        - Blaster Pod
+        - Sniper Pod
+        - Gatling Bike
+        - Hacker Tank
+        - Lightning Tank
+        - Stealth Tank
+        - Battleship
+
+    Superweapon:
+        - Air Strike
+        - Field Generator
+        - Orbital Railgun Strike
 
 faction-random =
    .name = Any
@@ -157,7 +157,7 @@ actor-gunship =
 
      {actor-gunship.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-jet =
    .description = Super Fast Interceptor
@@ -168,7 +168,7 @@ actor-jet =
 
      {actor-jet.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-jet2 =
    .description = Attack Bomber
@@ -180,7 +180,7 @@ actor-jet2 =
 
      {actor-jet2.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-copter =
    .name = Attack Helicopter
@@ -191,7 +191,7 @@ actor-copter =
 
      {actor-copter.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-saucer =
    .name = Scout Saucer
@@ -211,7 +211,7 @@ actor-observer =
 
      {actor-observer.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-banshee =
    .name = Banshee
@@ -223,7 +223,7 @@ actor-banshee =
 
      {actor-banshee.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-turtle =
    .name = Turtle
@@ -234,7 +234,7 @@ actor-turtle =
 
      {actor-turtle.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-chopper =
    .name = Transport Helicopter
@@ -245,7 +245,7 @@ actor-chopper =
 
      {actor-chopper.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-chopper-husk-name = Crashing Transport Helicopter
 
@@ -257,7 +257,7 @@ actor-balloon =
 
      Unarmed
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-dropship =
    .name = Heavy Transport Dropship
@@ -268,7 +268,7 @@ actor-dropship =
 
      {actor-dropship.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-dropship-husk-name = Crashing Transport Dropship
 actor-drone-name = Drone
@@ -597,7 +597,7 @@ actor-rocketeer =
 
      {actor-rocketeer.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-mortar =
    .description = Fast support vehicle.
@@ -609,7 +609,7 @@ actor-mortar =
 
       {actor-mortar.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-sniper =
    .description = Long range sniper vehicle.
@@ -621,7 +621,7 @@ actor-sniper =
 
      {actor-sniper.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-flamer =
    .description = Short range flame thrower.
@@ -632,7 +632,7 @@ actor-flamer =
 
      {actor-flamer.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-technician =
    .description = Field engineer.
@@ -679,7 +679,7 @@ actor-blaster =
 
      {actor-blaster.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-shocker =
    .description = Fast support vehicle.
@@ -691,7 +691,7 @@ actor-shocker =
 
      {actor-shocker.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 meta-minipod =
    .name = Civilian
@@ -738,7 +738,7 @@ actor-lightboat =
 
      {actor-lightboat.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-patrolboat =
    .name = Patrol boat
@@ -750,7 +750,7 @@ actor-patrolboat =
 
      {actor-patrolboat.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-mercboat =
    .name = Mercenary Boat
@@ -774,7 +774,7 @@ actor-torpedoboat =
 
      {actor-torpedoboat.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-submarine =
    .name = Submarine
@@ -786,7 +786,7 @@ actor-submarine =
 
      {actor-submarine.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-railgunboat =
    .name = Railgun Boat
@@ -797,7 +797,7 @@ actor-railgunboat =
 
      {actor-railgunpod.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-lightningboat =
    .name = Lightning Boat
@@ -808,7 +808,7 @@ actor-lightningboat =
 
      {actor-lightningboat.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-boomer =
    .name = Missile Submarine
@@ -819,7 +819,7 @@ actor-boomer =
 
      {actor-boomer.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-slcm-name = Submarine-launched cruise missile
 
@@ -831,7 +831,7 @@ actor-carrier =
 
      {actor-carrier.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-ferry =
    .name = Ferry
@@ -879,7 +879,7 @@ actor-aatank =
 
      {actor-aatank.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-aatank2 =
    .description = Mobile tank with lightning gun.
@@ -889,7 +889,7 @@ actor-aatank2 =
 
      {actor-aatank2.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-apc =
    .name = APC
@@ -953,7 +953,7 @@ actor-railguntank =
 
      {actor-railguntank.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-lightningtank =
    .description = Fires electric discharges.
@@ -964,7 +964,7 @@ actor-lightningtank =
 
      {actor-lightningtank.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-stealthtank =
    .description = Cloaked missile tank.
@@ -975,7 +975,7 @@ actor-stealthtank =
 
      {actor-stealthtank.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-merctank =
    .name = Mercenary Tank
@@ -1002,7 +1002,7 @@ actor-ecmtank =
 
      Unarmed
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-dualartillery =
    .name = Dual Artillery
@@ -1048,7 +1048,7 @@ actor-missiletank =
 
      {actor-missiletank.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-hackertank =
    .description = Temporarily changes allegiance of targeted units.
@@ -1059,7 +1059,7 @@ actor-hackertank =
 
      Unarmed
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-buggy =
    .name = Ramp Buggy
@@ -1071,7 +1071,7 @@ actor-buggy =
 
      {actor-buggy.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-bike =
    .name = Gatling Bike
@@ -1083,7 +1083,7 @@ actor-bike =
 
      {actor-bike.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-tanker1 =
    .description = Transports resources to the headquarter.
@@ -1119,7 +1119,7 @@ actor-mothership =
 
      {actor-mothership.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-mothership-husk =
    .name = Mothership Husk
@@ -1137,7 +1137,7 @@ actor-battleship =
 
      {actor-battleship.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-battleship-husk =
    .name = Battleship Husk

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -8,7 +8,7 @@ GUNSHIP:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 30
-		Prerequisites: ~starport.yi
+		Prerequisites: ~starport.sc
 		Description: actor-gunship.description
 	Encyclopedia:
 		Description: actor-gunship.encyclopedia
@@ -73,7 +73,7 @@ JET:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 50
-		Prerequisites: techcenter, ~starport.yi
+		Prerequisites: techcenter, ~starport.sc
 		Description: actor-jet.description
 	Encyclopedia:
 		Description: actor-jet.encyclopedia
@@ -132,7 +132,7 @@ JET2:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 55
-		Prerequisites: techcenter, ~starport.yi
+		Prerequisites: techcenter, ~starport.sc
 		Description: actor-jet2.description
 	Encyclopedia:
 		Description: actor-jet2.encyclopedia
@@ -216,7 +216,7 @@ COPTER:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 30
-		Prerequisites: ~starport.sc
+		Prerequisites: ~starport.yi
 		Description: actor-copter.description
 	Encyclopedia:
 		Description: actor-copter.encyclopedia
@@ -307,7 +307,7 @@ OBSERVER:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 20
-		Prerequisites: ~starport.sc
+		Prerequisites: ~starport.yi
 		Description: actor-observer.description
 	Encyclopedia:
 		Description: actor-observer.encyclopedia
@@ -352,7 +352,7 @@ BANSHEE:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 40
-		Prerequisites: techcenter, ~starport.sc
+		Prerequisites: techcenter, ~starport.yi
 		Description: actor-banshee.description
 	Encyclopedia:
 		Description: actor-banshee.encyclopedia
@@ -409,7 +409,7 @@ TURTLE:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 55
-		Prerequisites: techcenter, ~starport.sc
+		Prerequisites: techcenter, ~starport.yi
 		Description: actor-turtle.description
 	Encyclopedia:
 		Description: actor-turtle.encyclopedia
@@ -462,7 +462,7 @@ CHOPPER:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 50
-		Prerequisites: ~starport.sc
+		Prerequisites: ~starport.yi
 		Description: actor-chopper.description
 	Encyclopedia:
 		Description: actor-chopper.encyclopedia
@@ -558,7 +558,7 @@ BALLOON:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 20
-		Prerequisites: ~starport.yi
+		Prerequisites: ~starport.sc
 		Description: actor-balloon.description
 	Encyclopedia:
 		Description: actor-balloon.encyclopedia
@@ -604,7 +604,7 @@ DROPSHIP:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 50
-		Prerequisites: ~starport.yi
+		Prerequisites: ~starport.sc
 		Description: actor-dropship.description
 	Encyclopedia:
 		Description: actor-dropship.encyclopedia
@@ -898,7 +898,7 @@ MOTHERSHIP:
 		Queue: Aircraft
 		BuildPaletteOrder: 100
 		BuildLimit: 1
-		Prerequisites: radar, trader, techcenter, ~starport.sc
+		Prerequisites: radar, trader, techcenter, ~starport.yi
 		Description: actor-mothership.description
 	Encyclopedia:
 		Description: actor-mothership.encyclopedia
@@ -1030,7 +1030,7 @@ BATTLESHIP:
 		Queue: Aircraft
 		BuildPaletteOrder: 100
 		BuildLimit: 1
-		Prerequisites: radar, trader, techcenter, ~starport.yi
+		Prerequisites: radar, trader, techcenter, ~starport.sc
 		Description: actor-battleship.description
 	Encyclopedia:
 		Description: actor-battleship.encyclopedia

--- a/mods/hv/rules/bonus.yaml
+++ b/mods/hv/rules/bonus.yaml
@@ -36,19 +36,19 @@ SPAWNCUBE:
 		Sequence: blue
 	SpawnUnitCrateAction@AssaultTank:
 		Units: mbt
-		ValidFactions: yi
+		ValidFactions: sc
 		SelectionShares: 10
 	SpawnUnitCrateAction@mbt2:
 		Units: mbt2
-		ValidFactions: sc
+		ValidFactions: yi
 		SelectionShares: 10
 	SpawnUnitCrateAction@RailgunTank:
 		Units: railguntank
-		ValidFactions: sc
+		ValidFactions: yi
 		SelectionShares: 1
 	SpawnUnitCrateAction@LightningTank:
 		Units: lightningtank
-		ValidFactions: yi
+		ValidFactions: sc
 		SelectionShares: 1
 
 DUPLICATECUBE:

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -39,7 +39,7 @@ BASE:
 		Amount: 120
 	ProvidesPrerequisite@BuildingName:
 	ProvidesPrerequisite@Yuruki:
-		Prerequisite: structures.yi
+		Prerequisite: structures.sc
 	TechPrerequisiteWithBots:
 		Prerequisite: bots
 	Buildable:
@@ -47,7 +47,7 @@ BASE:
 		BuildPaletteOrder: 160
 		BuildLimit: 1
 		Description: actor-base.description
-		Prerequisites: outpost, ~base.yi
+		Prerequisites: outpost, ~base.sc
 	Encyclopedia:
 		Description: actor-base.encyclopedia
 		Order: 10
@@ -174,9 +174,9 @@ BASE2:
 		Image: base2
 	-ProvidesPrerequisite@Yuruki:
 	ProvidesPrerequisite@Synapol:
-		Prerequisite: structures.sc
+		Prerequisite: structures.yi
 	Buildable:
-		Prerequisites: outpost2, ~base.sc
+		Prerequisites: outpost2, ~base.yi
 	-Encyclopedia:
 
 OUTPOST:
@@ -211,14 +211,14 @@ OUTPOST:
 		RequiresCondition: !base
 	ProvidesPrerequisite@BuildingName:
 	ProvidesPrerequisite@Yuruki:
-		Prerequisite: base.yi
+		Prerequisite: base.sc
 
 OUTPOST2:
 	Inherits: OUTPOST
 	-ProvidesPrerequisite@Yuruki:
 	ProvidesPrerequisite@Synapol:
-		Factions: sc
-		Prerequisite: base.sc
+		Factions: yi
+		Prerequisite: base.yi
 	-Encyclopedia:
 
 GENERATOR:
@@ -262,8 +262,8 @@ GENERATOR:
 	RenderSprites:
 		Image: generator
 		FactionImages:
-			sc: generator2
-			yi: generator
+			yi: generator2
+			sc: generator
 
 RADAR:
 	Inherits: ^BaseBuilding
@@ -275,7 +275,7 @@ RADAR:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 90
-		Prerequisites: storage, ~structures.yi
+		Prerequisites: storage, ~structures.sc
 		Description: actor-radar.description
 	Encyclopedia:
 		Description: actor-radar.encyclopedia
@@ -337,7 +337,7 @@ RADAR:
 RADAR2:
 	Inherits: RADAR
 	Buildable:
-		Prerequisites: storage, ~structures.sc
+		Prerequisites: storage, ~structures.yi
 	-AirstrikePower:
 	DropPodsPower:
 		Cursor: droppod
@@ -453,8 +453,8 @@ TRADER:
 	RenderSprites:
 		Image: trader
 		FactionImages:
-			sc: trader2
-			yi: trader
+			yi: trader2
+			sc: trader
 
 MODULE:
 	Inherits: ^BaseBuilding
@@ -466,14 +466,14 @@ MODULE:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 30
-		Prerequisites: ~structures.yi
+		Prerequisites: ~structures.sc
 		Description: actor-module.description
 	Encyclopedia:
 		Description: actor-module.encyclopedia
 		Order: 50
 		Category: Buildings
 	ProvidesPrerequisite@Faction:
-		Prerequisite: module.yi
+		Prerequisite: module.sc
 		RequiresCondition: !powerdown
 	ProvidesPrerequisite@Generic:
 		Prerequisite: module
@@ -566,9 +566,9 @@ MODULE:
 MODULE2:
 	Inherits: MODULE
 	Buildable:
-		Prerequisites: ~structures.sc
+		Prerequisites: ~structures.yi
 	ProvidesPrerequisite@Faction:
-		Prerequisite: module.sc
+		Prerequisite: module.yi
 		RequiresCondition: !powerdown
 	RenderSprites:
 		Image: module2
@@ -656,7 +656,7 @@ STARPORT:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 120
-		Prerequisites: radar, ~structures.yi
+		Prerequisites: radar, ~structures.sc
 		Description: actor-starport.description
 	Valued:
 		Cost: 700
@@ -691,7 +691,7 @@ STARPORT:
 		Prerequisite: starport
 		RequiresCondition: !powerdown
 	ProvidesPrerequisite@Faction:
-		Prerequisite: starport.yi
+		Prerequisite: starport.sc
 		RequiresCondition: !powerdown
 	ProductionBar:
 		ProductionType: Aircraft
@@ -720,9 +720,9 @@ STARPORT:
 STARPORT2:
 	Inherits: STARPORT
 	Buildable:
-		Prerequisites: radar, ~structures.sc
+		Prerequisites: radar, ~structures.yi
 	ProvidesPrerequisite@Faction:
-		Prerequisite: starport.sc
+		Prerequisite: starport.yi
 		RequiresCondition: !powerdown
 	-WithProductionExitOverlay:
 	-Encyclopedia:
@@ -735,7 +735,7 @@ FACTORY:
 	Selectable:
 		Bounds: 2048, 4096
 	Buildable:
-		Prerequisites: module, storage, ~structures.yi
+		Prerequisites: module, storage, ~structures.sc
 		Queue: Building
 		BuildPaletteOrder: 90
 		Description: actor-factory.description
@@ -770,7 +770,7 @@ FACTORY:
 		Prerequisite: factory
 		RequiresCondition: !powerdown
 	ProvidesPrerequisite@Faction:
-		Prerequisite: factory.yi
+		Prerequisite: factory.sc
 		RequiresCondition: !powerdown
 	WithIdleOverlay@Platform1:
 		Sequence: idle-platform1
@@ -970,9 +970,9 @@ FACTORY:
 FACTORY2:
 	Inherits: FACTORY
 	Buildable:
-		Prerequisites: module, storage, ~structures.sc
+		Prerequisites: module, storage, ~structures.yi
 	ProvidesPrerequisite@Faction:
-		Prerequisite: factory.sc
+		Prerequisite: factory.yi
 		RequiresCondition: !powerdown
 	RenderSprites:
 		Image: factory2
@@ -1022,8 +1022,8 @@ TECHCENTER:
 	RenderSprites:
 		Image: techcenter
 		FactionImages:
-			sc: techcenter2
-			yi: techcenter
+			yi: techcenter2
+			sc: techcenter
 	WithIdleOverlay@ANIMATION:
 		Sequence: animation
 		RequiresCondition: !build-incomplete && !disabled && !burning
@@ -1045,7 +1045,7 @@ ORESMELT:
 		Queue: Building
 		BuildPaletteOrder: 130
 		Description: actor-oresmelt.description
-		Prerequisites: ~structures.sc, techcenter
+		Prerequisites: ~structures.yi, techcenter
 	HitShape:
 		Type: Rectangle
 			TopLeft: -512, -512
@@ -1074,7 +1074,7 @@ OREPURIFIER:
 		Name: actor-orepurifier.name
 	Buildable:
 		Description: actor-orepurifier.description
-		Prerequisites: ~structures.yi, techcenter
+		Prerequisites: ~structures.sc, techcenter
 	Encyclopedia:
 		Description: actor-orepurifier.encyclopedia
 	-WithIdleOverlay@Shadow:
@@ -1086,7 +1086,7 @@ BUNKER:
 	Inherits@AutoTarget: ^AutoTargetGround
 	Buildable:
 		BuildPaletteOrder: 80
-		Prerequisites: module, ~structures.yi
+		Prerequisites: module, ~structures.sc
 		Description: actor-bunker.description
 	Selectable:
 		Bounds: 1256, 1480, 0, -256
@@ -1133,7 +1133,7 @@ BUNKER:
 BUNKER2:
 	Inherits: BUNKER
 	Buildable:
-		Prerequisites: module, ~structures.sc
+		Prerequisites: module, ~structures.yi
 	AttackGarrisoned:
 		PortOffsets: 175,0,350, 125,-280,175, -125,-280,175, -225,0,200, -125,280,175, 125,280,175
 	-Encyclopedia:
@@ -1143,7 +1143,7 @@ TURRET:
 	Inherits@AutoTarget: ^AutoTargetGround
 	Buildable:
 		BuildPaletteOrder: 90
-		Prerequisites: factory, ~structures.yi
+		Prerequisites: factory, ~structures.sc
 		Description: actor-turret.description
 	Valued:
 		Cost: 1000
@@ -1182,7 +1182,7 @@ TURRET2:
 	Inherits@AutoTarget: ^AutoTargetGround
 	Buildable:
 		BuildPaletteOrder: 90
-		Prerequisites: factory, ~structures.sc
+		Prerequisites: factory, ~structures.yi
 		Description: actor-turret2.description
 	Valued:
 		Cost: 1000
@@ -1221,7 +1221,7 @@ AATURRET:
 		Bounds: 2048, 1536, 0, -256
 	Buildable:
 		BuildPaletteOrder: 90
-		Prerequisites: radar, ~structures.yi
+		Prerequisites: radar, ~structures.sc
 		Description: actor-aaturret.description
 	Valued:
 		Cost: 1000
@@ -1268,7 +1268,7 @@ AATURRET2:
 	Inherits@AutoTarget: ^AutoTargetAir
 	Buildable:
 		BuildPaletteOrder: 90
-		Prerequisites: radar, ~structures.sc
+		Prerequisites: radar, ~structures.yi
 		Description: actor-aaturret2.description
 	Valued:
 		Cost: 1000
@@ -1308,7 +1308,7 @@ HOWITZER:
 		Bounds: 2048, 2048
 	Buildable:
 		BuildPaletteOrder: 90
-		Prerequisites: radar, ~structures.sc
+		Prerequisites: radar, ~structures.yi
 		Description: actor-howitzer.description
 		BuildLimit: 1
 	Valued:
@@ -1380,7 +1380,7 @@ FIELD:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 90
-		Prerequisites: radar, ~structures.yi
+		Prerequisites: radar, ~structures.sc
 		BuildLimit: 1
 		Description: actor-field.description
 	Valued:
@@ -1444,8 +1444,8 @@ FIELD:
 	RenderSprites:
 		Image: field
 		FactionImages:
-			sc: field2
-			yi: field
+			yi: field2
+			sc: field
 
 SILO:
 	Inherits: ^BaseBuilding
@@ -1465,7 +1465,7 @@ SILO:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 140
-		Prerequisites: techcenter, ~structures.sc
+		Prerequisites: techcenter, ~structures.yi
 		BuildLimit: 1
 		Description: actor-silo.description
 	Building:
@@ -1540,7 +1540,7 @@ UPLINK:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 140
-		Prerequisites: techcenter, ~structures.yi
+		Prerequisites: techcenter, ~structures.sc
 		BuildLimit: 1
 		Description: actor-uplink.description
 	Building:
@@ -1636,8 +1636,8 @@ STORAGE:
 	RenderSprites:
 		Image: storage2
 		FactionImages:
-			sc: storage
-			yi: storage2
+			yi: storage
+			sc: storage2
 	ExitsDebugOverlay:
 	Exit@Top:
 		ExitCell: 2, 0
@@ -1787,7 +1787,7 @@ HARBOR:
 	Selectable:
 		Bounds: 3072, 2348, 0, -560
 	Buildable:
-		Prerequisites: module, ~structures.yi
+		Prerequisites: module, ~structures.sc
 		Queue: Building
 		BuildPaletteOrder: 90
 		Description: actor-harbor.description
@@ -1860,7 +1860,7 @@ HARBOR:
 		Prerequisite: harbor
 		RequiresCondition: !powerdown
 	ProvidesPrerequisite@Faction:
-		Prerequisite: harbor.yi
+		Prerequisite: harbor.sc
 		RequiresCondition: !powerdown
 	WithTextDecoration@PRIMARY:
 		RequiresCondition: primary
@@ -1890,10 +1890,10 @@ HARBOR2:
 	RenderSprites:
 		Image: harbor2
 	ProvidesPrerequisite@Faction:
-		Prerequisite: harbor.sc
+		Prerequisite: harbor.yi
 		RequiresCondition: !powerdown
 	Buildable:
-		Prerequisites: module, ~structures.sc
+		Prerequisites: module, ~structures.yi
 	-Encyclopedia:
 
 BARRIER:

--- a/mods/hv/rules/pods.yaml
+++ b/mods/hv/rules/pods.yaml
@@ -46,7 +46,7 @@ ROCKETEER:
 	Buildable:
 		Queue: Pod
 		Description: actor-rocketeer.description
-		Prerequisites: ~module.sc
+		Prerequisites: ~module.yi
 		BuildPaletteOrder: 20
 	Encyclopedia:
 		Description: actor-rocketeer.encyclopedia
@@ -84,7 +84,7 @@ MORTAR:
 	Buildable:
 		Queue: Pod
 		Description: actor-mortar.description
-		Prerequisites: ~module.sc, factory
+		Prerequisites: ~module.yi, factory
 		BuildPaletteOrder: 50
 	Encyclopedia:
 		Description: actor-mortar.encyclopedia
@@ -124,7 +124,7 @@ SNIPER:
 	Buildable:
 		Queue: Pod
 		Description: actor-sniper.description
-		Prerequisites: ~module.yi, radar
+		Prerequisites: ~module.sc, radar
 		BuildPaletteOrder: 50
 	Encyclopedia:
 		Description: actor-sniper.encyclopedia
@@ -175,7 +175,7 @@ FLAMER:
 	Buildable:
 		Queue: Pod
 		Description: actor-flamer.description
-		Prerequisites: ~module.sc, factory
+		Prerequisites: ~module.yi, factory
 		BuildPaletteOrder: 40
 	Encyclopedia:
 		Description: actor-flamer.encyclopedia
@@ -377,7 +377,7 @@ BLASTER:
 	Buildable:
 		Queue: Pod
 		Description: actor-blaster.description
-		Prerequisites: ~module.yi, radar
+		Prerequisites: ~module.sc, radar
 		BuildPaletteOrder: 40
 	Encyclopedia:
 		Description: actor-blaster.encyclopedia
@@ -428,7 +428,7 @@ SHOCKER:
 	Buildable:
 		Queue: Pod
 		Description: actor-shocker.description
-		Prerequisites: ~module.yi
+		Prerequisites: ~module.sc
 		BuildPaletteOrder: 20
 	Encyclopedia:
 		Description: actor-shocker.encyclopedia

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -11,7 +11,7 @@ LIGHTBOAT:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.yi
+		Prerequisites: ~harbor.sc
 		BuildPaletteOrder: 10
 		Description: actor-lightboat.description
 	Encyclopedia:
@@ -59,7 +59,7 @@ PATROLBOAT:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.sc
+		Prerequisites: ~harbor.yi
 		BuildPaletteOrder: 10
 		Description: actor-patrolboat.description
 	Encyclopedia:
@@ -158,7 +158,7 @@ TORPEDOBOAT:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.yi, radar
+		Prerequisites: ~harbor.sc, radar
 		BuildPaletteOrder: 30
 		Description: actor-torpedoboat.description
 	Encyclopedia:
@@ -201,7 +201,7 @@ SUBMARINE:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.sc, radar
+		Prerequisites: ~harbor.yi, radar
 		BuildPaletteOrder: 30
 		Description: actor-submarine.description
 	Encyclopedia:
@@ -244,7 +244,7 @@ RAILGUNBOAT:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.sc, techcenter
+		Prerequisites: ~harbor.yi, techcenter
 		BuildPaletteOrder: 50
 		Description: actor-railgunboat.description
 	Encyclopedia:
@@ -288,7 +288,7 @@ LIGHTNINGBOAT:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.yi, techcenter
+		Prerequisites: ~harbor.sc, techcenter
 		BuildPaletteOrder: 50
 		Description: actor-lightningboat.description
 	Encyclopedia:
@@ -333,7 +333,7 @@ BOOMER:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.sc, techcenter
+		Prerequisites: ~harbor.yi, techcenter
 		BuildPaletteOrder: 60
 		Description: actor-boomer.description
 	Encyclopedia:
@@ -409,7 +409,7 @@ CARRIER:
 	Buildable:
 		Queue: Ship
 		BuildPaletteOrder: 60
-		Prerequisites: ~harbor.yi, techcenter
+		Prerequisites: ~harbor.sc, techcenter
 		Description: actor-carrier.description
 	Encyclopedia:
 		Description: actor-carrier.encyclopedia
@@ -512,7 +512,7 @@ MINESHIP:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.sc, trader
+		Prerequisites: ~harbor.yi, trader
 		BuildPaletteOrder: 40
 		Description: actor-mineship.description
 	Encyclopedia:
@@ -570,5 +570,5 @@ MINESHIP:
 MINESHIP2:
 	Inherits: MINESHIP
 	Buildable:
-		Prerequisites: ~harbor.yi, trader
+		Prerequisites: ~harbor.sc, trader
 	-Encyclopedia:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -13,7 +13,7 @@ MBT:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 10
-		Prerequisites: ~factory.yi
+		Prerequisites: ~factory.sc
 		Queue: Tank
 		Description: actor-mbt.description
 	Encyclopedia:
@@ -53,7 +53,7 @@ MBT:
 MBT2:
 	Inherits: MBT
 	Buildable:
-		Prerequisites: ~factory.sc
+		Prerequisites: ~factory.yi
 	-Encyclopedia:
 	Turreted:
 		Offset: 0,0,0
@@ -67,7 +67,7 @@ AATANK:
 	Buildable:
 		Queue: Tank
 		BuildPaletteOrder: 20
-		Prerequisites: ~factory.sc
+		Prerequisites: ~factory.yi
 		Description: actor-aatank.description
 	Encyclopedia:
 		Description: actor-aatank.encyclopedia
@@ -110,7 +110,7 @@ AATANK:
 AATANK2:
 	Inherits: AATANK
 	Buildable:
-		Prerequisites: ~factory.yi
+		Prerequisites: ~factory.sc
 		Description: actor-aatank2.description
 	Encyclopedia:
 		Description: actor-aatank2.encyclopedia
@@ -427,7 +427,7 @@ RAILGUNTANK:
 		Class: railguntank
 	Buildable:
 		Queue: Tank
-		Prerequisites: ~factory.sc, techcenter
+		Prerequisites: ~factory.yi, techcenter
 		BuildPaletteOrder: 70
 		Description: actor-railguntank.description
 	Armament:
@@ -459,7 +459,7 @@ LIGHTNINGTANK:
 	Buildable:
 		Queue: Tank
 		BuildPaletteOrder: 70
-		Prerequisites: ~factory.yi, techcenter
+		Prerequisites: ~factory.sc, techcenter
 		Description: actor-lightningtank.description
 	Encyclopedia:
 		Description: actor-lightningtank.encyclopedia
@@ -503,7 +503,7 @@ STEALTHTANK:
 	Buildable:
 		Queue: Tank
 		BuildPaletteOrder: 80
-		Prerequisites: ~factory.yi, techcenter
+		Prerequisites: ~factory.sc, techcenter
 		Description: actor-stealthtank.description
 	Encyclopedia:
 		Description: actor-stealthtank.encyclopedia
@@ -629,7 +629,7 @@ ECMTANK:
 		Class: ecmtank
 	Buildable:
 		Queue: Tank
-		Prerequisites: ~factory.yi, radar, trader
+		Prerequisites: ~factory.sc, radar, trader
 		BuildPaletteOrder: 60
 		Description: actor-ecmtank.description
 	Encyclopedia:
@@ -726,7 +726,7 @@ BUILDER:
 		Queue: Utility
 		BuildPaletteOrder: 10
 		Description: actor-builder.description
-		Prerequisites: ~structures.yi
+		Prerequisites: ~structures.sc
 	Encyclopedia:
 		Description: actor-builder.encyclopedia
 		Order: 15
@@ -775,7 +775,7 @@ BUILDER:
 BUILDER2:
 	Inherits: BUILDER
 	Buildable:
-		Prerequisites: ~structures.sc
+		Prerequisites: ~structures.yi
 	-Encyclopedia:
 	Transforms:
 		IntoActor: outpost2
@@ -878,7 +878,7 @@ MISSILETANK:
 		Class: missiletank
 	Buildable:
 		Queue: Tank
-		Prerequisites: ~factory.sc, radar, techcenter
+		Prerequisites: ~factory.yi, radar, techcenter
 		BuildPaletteOrder: 80
 		Description: actor-missiletank.description
 	Encyclopedia:
@@ -916,7 +916,7 @@ HACKERTANK:
 	Buildable:
 		Queue: Tank
 		BuildPaletteOrder: 60
-		Prerequisites: ~factory.sc, radar, trader
+		Prerequisites: ~factory.yi, radar, trader
 		Description: actor-hackertank.description
 	Encyclopedia:
 		Description: actor-hackertank.encyclopedia
@@ -980,7 +980,7 @@ BUGGY:
 		Class: buggy
 	Buildable:
 		BuildPaletteOrder: 30
-		Prerequisites: module, ~factory.sc
+		Prerequisites: module, ~factory.yi
 		Queue: Tank
 		Description: actor-buggy.description
 	Encyclopedia:
@@ -1027,7 +1027,7 @@ BIKE:
 		Class: bike
 	Buildable:
 		Queue: Tank
-		Prerequisites: module, ~factory.yi
+		Prerequisites: module, ~factory.sc
 		BuildPaletteOrder: 30
 		Description: actor-bike.description
 	Encyclopedia:
@@ -1090,7 +1090,7 @@ TANKER1:
 	RenderSprites:
 		Image: tanker1
 		FactionImages:
-			sc: tanker3
+			yi: tanker3
 
 TANKER2:
 	Inherits: TANKER1
@@ -1109,7 +1109,7 @@ TANKER2:
 	RenderSprites:
 		Image: tanker2
 		FactionImages:
-			sc: tanker4
+			yi: tanker4
 
 CVIT:
 	Inherits: ^Vehicle

--- a/mods/hv/rules/world.yaml
+++ b/mods/hv/rules/world.yaml
@@ -174,7 +174,7 @@
 	Faction@Random:
 		Name: faction-random.name
 		InternalName: Random
-		RandomFactionMembers: yi, sc
+		RandomFactionMembers: sc, yi
 		Side: Random
 		Description: faction-random.description
 	PaletteFromGimpOrJascFile@Terrain:
@@ -477,35 +477,35 @@ World:
 	StartingUnits@BaseYI:
 		Class: none
 		ClassName: options-starting-units.base-only
-		Factions: yi
+		Factions: sc
 		BaseActor: base
 	StartingUnits@BaseSC:
 		Class: none
 		ClassName: options-starting-units.base-only
-		Factions: sc
+		Factions: yi
 		BaseActor: base2
 	StartingUnits@MinerYI:
 		Class: miner
 		ClassName: options-starting-units.base-miner
-		Factions: yi
+		Factions: sc
 		BaseActor: base
 		SupportActors: miner
 	StartingUnits@MinerSC:
 		Class: miner
 		ClassName: options-starting-units.base-miner
-		Factions: sc
+		Factions: yi
 		BaseActor: base2
 		SupportActors: miner
 	StartingUnits@ScoutYI:
 		Class: scout
 		ClassName: options-starting-units.base-scout
-		Factions: yi
+		Factions: sc
 		BaseActor: base
 		SupportActors: balloon
 	StartingUnits@ScoutSC:
 		Class: scout
 		ClassName: options-starting-units.base-scout
-		Factions: sc
+		Factions: yi
 		BaseActor: base2
 		SupportActors: observer
 	MapStartingLocations:


### PR DESCRIPTION
.. , as in my mind, this better matches their background, Logo and names. I'm assuming here that a least most new players would feel this way as well.

Switched all short-name (sc, yi) references in /rules, and all "Availability:" references in the Encyclopedia references.

Missions / campaign is left untouched as of now (but I was looking at delving in there anyhow).