### PR TITLE
Fix Ore on Black Sand, and Miner being deployable on Red Snow

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -619,7 +619,7 @@ MINER2:
 		Footprint: ++ ++ xx
 		Dimensions: 2,3
 		RequiresBaseProvider: false
-		TerrainTypes: Clear, Road, Crater, Grass, Grass Pit, Ore, Mountain, Rock, Ice, Snow, Sand, Black Sand, Stone, Tech, Dirt, Blocked
+		TerrainTypes: Clear, Road, Crater, Grass, Grass Pit, Ore, Mountain, Rock, Ice, Snow, Red Snow, Sand, Black Sand, Stone, Tech, Dirt, Blocked
 		AllowPlacementOnResources: true
 	RevealsShroud:
 		Range: 5c0

--- a/mods/hv/rules/world.yaml
+++ b/mods/hv/rules/world.yaml
@@ -302,12 +302,12 @@ World:
 			gold:
 				ResourceIndex: 1
 				TerrainType: Ore
-				AllowedTerrainTypes: Clear, Crater, Grass, Grass Pit, Road, Mountain, Snow, Red Snow, Sand, Plant, Tech, Dirt
+				AllowedTerrainTypes: Clear, Crater, Grass, Grass Pit, Road, Mountain, Ice, Snow, Red Snow, Sand, Black Sand, Plant, Stone, Tech, Dirt
 				MaxDensity: 3
 			iron:
 				ResourceIndex: 2
 				TerrainType: Ore
-				AllowedTerrainTypes: Clear, Crater, Grass, Grass Pit, Road, Mountain, Snow, Red Snow, Sand, Plant, Tech, Dirt
+				AllowedTerrainTypes: Clear, Crater, Grass, Grass Pit, Road, Mountain, Ice, Snow, Red Snow, Sand, Black Sand, Plant, Stone, Tech, Dirt
 				MaxDensity: 3
 			bridge-shadow-left:
 				ResourceIndex: 3


### PR DESCRIPTION
Change world.yaml and buildings.yaml to add entries for "Black Sand" (as a valid Ore Terrain type) and "Red Snow" (as a buildable terrain type for the Miner) - thus fixing ore not being usable on these two terrain types.

Placing Ore on "Tech" terrain will still not work - but hasn't for quite some time from what I can tell (I checked on the last stable release, plus any maps using Tech terrain (eg. business as usual) place dirt under the Ore. (Intentional that it can't be placed on Tech?).

Thus partly fixes #1234   (ooh, neat bug number ;P  ).

(I also added Ice and Stone as valid Terrain Ore Terrain types, but - as with Tech - placing ore on these does not actually work in the map editor.)
