### PR TITLE
Draft: Change Factions Symmetry - Phase 1

### DIFF
--- a/OpenRA.Mods.HV/Traits/SupportPowers/DropPodsPower.cs
+++ b/OpenRA.Mods.HV/Traits/SupportPowers/DropPodsPower.cs
@@ -56,6 +56,7 @@ namespace OpenRA.Mods.HV.Traits
 		readonly DropPodsPowerInfo info;
 		readonly AircraftInfo aircraftInfo;
 		readonly FallsToEarthInfo fallsToEarthInfo;
+		public readonly int DropAmount = 8;
 
 		public DropPodsPower(Actor self, DropPodsPowerInfo info)
 			: base(self, info)
@@ -122,15 +123,14 @@ namespace OpenRA.Mods.HV.Traits
 
 				PlayLaunchSounds();
 
-				var drops = self.World.SharedRandom.Next(info.Drops.X, info.Drops.Y);
-				for (var i = 0; i < drops; i++)
+				var dropTypes = info.UnitTypes.Length;
+
+				for (var i = 0; i < DropAmount; i++)
 				{
-					var unitType = info.UnitTypes.Random(self.World.SharedRandom);
 					var podLocation = podLocations.Random(self.World.SharedRandom);
-					var podTarget = Target.FromCell(w, podLocation);
 					var location = self.World.Map.CenterOfCell(podLocation) - delta + new WVec(0, 0, altitude);
 
-					var pod = w.CreateActor(false, unitType,
+					var pod = w.CreateActor(false, info.UnitTypes[i % dropTypes],
 					[
 						new CenterPositionInit(location),
 						new OwnerInit(self.Owner),

--- a/mods/hv/fluent/rules.ftl
+++ b/mods/hv/fluent/rules.ftl
@@ -192,11 +192,11 @@ actor-jet2 =
      Availability: Yuruki
 
 actor-copter =
-   .name = Attack Helicopter
+   .name = Assault Helicopter
    .description = Small Helicopter Gunship
       Strong vs Pods, Buildings and Aircraft
       Weak vs Tanks
-   .encyclopedia = The attack helicopter is a small helicopter, armed with a turret heavy machine gun. It's a versatile unit, often used to harass the opponents' mining towers and outposts.
+   .encyclopedia = The assault helicopter is a small helicopter, armed with a turret heavy machine gun. It's a versatile unit, often used to harass the opponents' mining towers and outposts.
 
      {actor-copter.description}
 
@@ -216,7 +216,7 @@ actor-observer =
    .name = Observer
    .description = Reconnaissance air unit.
       Unarmed
-   .encyclopedia = An orb shaped helicopter with good maneuverability. It's not suited for combat, but for reconnaissance missions.
+   .encyclopedia = An orb shaped helicopter with scouting capabilities. It's not suited for combat, but for reconnaissance missions.
 
      {actor-observer.description}
 
@@ -262,7 +262,7 @@ actor-balloon =
    .name = Scout Balloon
    .description = Reconnaissance air unit.
      Unarmed
-   .encyclopedia = A reconnaissance air unit. It's slower than Synapol's observer, but it grants more visibility range.
+   .encyclopedia = A reconnaissance air unit with scouting capabilities. It's not suited for combat, but for reconnaissance missions.
 
      Unarmed
 
@@ -747,36 +747,52 @@ actor-technician =
     Repairs pods.
       Unarmed
    .name = Technician
-   .encyclopedia = The universal field engineer. Its first ability is to infiltrate and capture enemy structures, changing their allegiance: it is often used to capture enemy mining towers. Its second ability is to repair allied pods, on the battle field.
+   .encyclopedia = The Synapol's field engineer. Its first ability is to infiltrate and capture enemy structures, changing their allegiance. Its second ability is to repair allied pods, on the battle field.
 
      {actor-technician.description}
 
-     Availability: Universal
+     Availability: Synapol
 
 actor-broker =
    .description = Financial analyst.
+    Infiltrates and captures enemy structures.
     Invests into stock market for dividends.
     Capable of remotely stealing money
-    from bases and storages.
+    from bases, storages, mining towers, ore
+    smelters or ore purifiers, once deployed
       Unarmed
    .name = Broker
-   .encyclopedia = The broker pod is an advanced pod that can invest in the stock market for a constant stream of revenue. It can also tap into an opponent's base or storage and initiate forged wire transfers to remotely steal that enemy's cash.
+   .encyclopedia = The broker pod is an advanced pod that can tap into an opponent's base, storage, mining tower, ore smelter or ore purifier and initiate forged wire transfers to remotely steal that enemy's cash, when deployed. It can also infiltrate and capture enemy structures, when undeployed.
 
      {actor-broker.description}
 
-     Availability: Universal
+     Availability: Yuruki
 
 actor-jetpacker =
    .description = Elite airborne vehicle.
-    Armed with heavy machine gun.
-      Strong vs Pods, Light Vehicles and Aircraft
-      Weak vs Tanks and Buildings
+    Armed with heavy missiles.
+      Strong vs Pods
+      Weak vs Vehicles, Navy and Buildings
+      Can't attack Aircraft
    .name = Jetpacker
-   .encyclopedia = The ultimate pod: the jetpacker. It was designed by an independent lab, allowing its universal availability. It can handle pods, light vehicles and aircraft well. The fact that it's an airborne pod makes it less vulnerable to other pods.
+   .encyclopedia = The ultimate Synapol pod: the jetpacker. It was designed to weaken Yuruki pod masses. The fact that it's an airborne pod makes it less vulnerable to other pods.
 
      {actor-jetpacker.description}
 
-     Availability: Universal
+     Availability: Synapol
+
+actor-jetpacker2 =
+   .description = Elite airborne vehicle.
+    Armed with scatter gun.
+      Strong vs Vehicles, Navy
+      Weak vs Pods and Buildings
+      Can't attack Aircraft
+   .name = Jetpacker2
+   .encyclopedia = The ultimate Yuruki pod: the jetpacker. It was designed for quick maneuverability and hit-and-run tactics to weaken Synapol's vehicle and navy forces. The fact that it's an airborne pod makes it less vulnerable to other pods.
+
+     {actor-jetpacker2.description}
+
+     Availability: Yuruki
 
 actor-blaster =
    .description = Remote controlled mine.
@@ -845,7 +861,7 @@ actor-lightboat =
 
      {actor-lightboat.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-patrolboat =
    .name = Patrol boat
@@ -857,31 +873,32 @@ actor-patrolboat =
 
      {actor-patrolboat.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-mercboat =
    .name = Mercenary Boat
    .generic-name = Boat
    .description = A boat with a turret.
-      Strong vs Vehicles
+      Strong vs Vehicles, Navy and Buildings
       Weak vs Pods
-   .encyclopedia = The mercenary boat is a fast boat, armed with a turret. Its turret is powerful against other ships.
+      Can't attack Aircraft
+   .encyclopedia = The mercenary boat is a fast boat, armed with a turret, making it a flexible medium unit.
 
      {actor-mercboat.description}
 
-     Availability: Non-trainable
+     Availability: Synapol
 
 actor-torpedoboat =
    .name = Torpedo Boat
    .generic-name = Boat
    .description = A boat with torpedo launchers.
       Strong vs Water
-      Can't attack Ground or Air
+      Can't attack Ground or Aircraft
    .encyclopedia = The torpedo boat is designed to counter fast ship assaults. It has two torpedo launchers onboard that can take down multiple boats on its own.
 
      {actor-torpedoboat.description}
 
-     Availability: Yuruki
+     Availability: Non-trainable
 
 actor-submarine =
    .name = Submarine
@@ -893,7 +910,7 @@ actor-submarine =
 
      {actor-submarine.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-railgunboat =
    .name = Railgun Boat
@@ -909,9 +926,13 @@ actor-railgunboat =
 actor-lightningboat =
    .name = Lightning Boat
    .generic-name = Boat
-   .description = A heavy boat with a lightning gun.
-      Strong vs Vehicles, Pods and Buildings
-   .encyclopedia = The lightning boat is a heavy ship capable of handling every situation possible. It's armed with a 360 degrees laser zap, that's particularly powerful against buildings.
+   .description = A heavy boat with a lightning
+   aura that increases the rate of fire of most
+   friendly navy units nearby.
+      Unarmed
+   .encyclopedia = The lightning boat is a heavy ship that aids nearby navy units. It eletrifies the waters nearby and that makes all friendly navy unit weapon mechanisms electrified (except for Missile Submarine and Drone Ship), increasing their rate of fire slightly.
+
+   Unarmed
 
      {actor-lightningboat.description}
 
@@ -926,7 +947,7 @@ actor-boomer =
 
      {actor-boomer.description}
 
-     Availability: Synapol
+     Availability: Yuruki
 
 actor-slcm-name = Submarine-launched cruise missile
 
@@ -938,7 +959,7 @@ actor-carrier =
 
      {actor-carrier.description}
 
-     Availability: Yuruki
+     Availability: Synapol
 
 actor-ferry =
    .name = Light Naval transporter
@@ -1177,9 +1198,9 @@ actor-missiletank =
    .name = Missile Tank
    .generic-name = Tank
    .description = A tank which shoots missiles.
-      Strong vs Vehicles and Buildings
+      Strong vs Vehicles, Aircraft, Navy and Buildings
       Weak vs Pods
-   .encyclopedia = The missile tank is an agile tank, able to fire from a turret, while still moving decently fast. It is armed with a powerful missile launcher, extremely powerful against buildings. It is yet less versatile than the railgun tank, it is stronger against buildings.
+   .encyclopedia = The missile tank is slow but powerful, able to fire from a turret. It is armed with a powerful missile launcher, good against buildings, vehicles and air units.
 
      {actor-missiletank.description}
 
@@ -1250,7 +1271,7 @@ actor-mothership =
    .description = Launches aerial autonomous attack vessels.
       Only one can be built.
       Strong vs Everything
-   .encyclopedia = When the Yuruki colony on Mars started their battleship design program, the Synapol Corporations had to design themselves a massive air unit to counter the battleship. The mothership was their solution. It's a real floating city: it regroups a crew of 2,500 men, and has many different quarters, some being science labs, other armament testing... It is armed with two powerful plasma turreted canon that can target ground structures, and with a drone bay, containing five of them. When a drone is destroyed, another one is immediately reproduced.
+   .encyclopedia = When the Yuruki colony on Mars started their battleship design program, the Synapol Corporations had to design themselves a massive air unit to counter the battleship. The mothership was their solution. It's a real floating city: it regroups a crew of 2,500 men, and has many different quarters, some being science labs, other armament testing... It is armed with four powerful plasma turreted canon that can target ground structures, and with a drone bay, containing five of them. When a drone is destroyed, another one is immediately reproduced.
 
      {actor-mothership.description}
 

--- a/mods/hv/fluent/rules.ftl
+++ b/mods/hv/fluent/rules.ftl
@@ -247,10 +247,10 @@ actor-turtle =
 
 actor-chopper =
    .name = Transport Helicopter
-   .description = Vehicle Transport Helicopter.
+   .description = Transport Helicopter.
       Can load pods
       and lift one vehicle.
-   .encyclopedia = The chopper is a heavy transport aircraft that can load a group of pods. It can also lift one vehicle.
+   .encyclopedia = The chopper is a heavy transport aircraft that can load a group of pods or vehicles.
 
      {actor-chopper.description}
 
@@ -269,11 +269,11 @@ actor-balloon =
      Availability: Yuruki
 
 actor-dropship =
-   .name = Heavy Transport Dropship
-   .description = Vehicle Transport Shuttle.
+   .name = Transport Dropship
+   .description = Transport Shuttle.
       Can load pods
       and lift one vehicle.
-   .encyclopedia = The dropship is a heavy transport aircraft, than can load up a group of pods. It can also lift one vehicle.
+   .encyclopedia = The dropship is a fast transport aircraft, than can load up a group of pods or vehicles.
 
      {actor-dropship.description}
 
@@ -941,8 +941,8 @@ actor-carrier =
      Availability: Yuruki
 
 actor-ferry =
-   .name = Ferry
-   .generic-name = Naval Transporter
+   .name = Light Naval transporter
+   .generic-name = Ferry
    .description = General-purpose naval transport.
     Can carry pods.
       Unarmed
@@ -950,7 +950,19 @@ actor-ferry =
 
      {actor-ferry.description}
 
-     Availability: Universal
+     Availability: Yuruki
+
+actor-ferry2 =
+   .name = Heavy Naval Transporter
+   .generic-name = Ferry
+   .description = General-purpose naval transport.
+    Can carry pods.
+      Unarmed
+   .encyclopedia = The ferry is a heavy naval transporter based on liquid leviation technology that only works on water. It is quite slow but very durable. It can land on shores to load or unload its cargo.
+
+     {actor-ferry2.description}
+
+     Availability: Synapol
 
 actor-mineship =
    .name = Naval Minelayer
@@ -999,12 +1011,20 @@ actor-aatank2 =
      Availability: Yuruki
 
 actor-apc =
-   .name = APC
+   .name = Light APC
    .description = Can transport pods.
       Has fireports for garrisoned units.
    .encyclopedia = The Armored Personal Carriers (APC) is a durable transport tank. It is used to carry pods, giving them better protection, while still being able to fire through firing ports. It was designed to conduct assault missions, when you don't have enough resources to produce tanks.
 
-     Availability: Universal
+     Availability: Yuruki
+
+actor-apc2 =
+   .name = Heavy APC
+   .description = Can transport pods.
+      Has fireports for garrisoned units.
+   .encyclopedia = The Armored Personal Carriers (APC) is a durable transport tank. It is used to carry pods, giving them better protection, while still being able to fire through firing ports. It was designed to conduct assault missions, when you don't have enough resources to produce tanks.
+
+     Availability: Synapol
 
 actor-artillery =
    .name = Artillery

--- a/mods/hv/fluent/rules.ftl
+++ b/mods/hv/fluent/rules.ftl
@@ -19,22 +19,43 @@ faction-yuruki =
     Their colonial defense forces helped pave the way for
     an aggressive expansion throughout the solar system.
 
-    Faction Variations:
-        - Uses fighter jets as air units
+    Strategy:
+        - Focuses on stealth and specialized combat units
+        - Transport and aerial scout units are faster but
+          less resistant
 
-    Special Units:
-        - Shocker Pod
-        - Blaster Pod
-        - Sniper Pod
-        - Gatling Bike
-        - Hacker Tank
-        - Lightning Tank
-        - Stealth Tank
-        - Battleship
+    Specific Combat Units:
 
-    Superweapon:
+        Pods:
+        - Sniper (cloaked anti-pod)
+        - Shocker (anti-vehicle, anti-building and anti-air)
+        - Bomber (suicidal anti-ground)
+        - Jetfoiler (floating anti-vehicle)
+
+        Vehicles:
+        - Lightning Tank (anti-vehicle and anti-building)
+        - Mobile AA Tank (anti-air)
+        - Gatling Bike (anti-pod)
+        - Countermeasure Tank (specialist)
+        - Stealth Tank (cloaked anti-ground)
+
+        Aircraft:
+        - Gun Ship (anti-ground and anti-air)
+        - Speeder (anti-air)
+        - Athmospheric Bomber (cloaked anti-ground)
+
+        Navy:
+        - Patrol Boat (anti-ground and anti-air)
+        - Submarine (underwater anti-water)
+        - Lightning Boat (anti-ground)
+        - Missile Submarine (underwater anti-ground)
+
+    Superunit:
+        - Battleship (anti-ground)
+
+    Superweapons:
         - Air Strike
-        - Field Generator
+        - Force Field Generator
         - Orbital Railgun Strike
 
 faction-synapol =
@@ -44,21 +65,41 @@ faction-synapol =
     everything from common household appliances to armaments.
     Their security department became a large paramilitary force.
 
-    Faction Variations:
-        - Uses helicopters as air units
-        - Uses submarines as advanced naval units
+    Strategy:
+        - Focuses on brute force and flexible combat units
+        - Transport and aerial scout units are slower but
+          more resistant
 
-    Special Units:
-        - Rocketeer Pod
-        - Flamer Pod
-        - Mortar Pod
-        - Ramp Buggy
-        - Countermeasure Tank
-        - Railgun Tank
-        - Missile Tank
-        - Mothership
+    Specific Combat Units:
 
-    Superweapon:
+        Pods:
+        - Mortar Pod (anti-ground)
+        - Rocketeer Pod (anti-vehicle, anti-building and anti-air)
+        - Flamer Pod (anti-ground)
+        - Jetpacker Pod (floating anti-pod)
+
+        Vehicles:
+        - Missile Tank (anti-vehicle, anti-building and anti-air)
+        - Artillery Tank (anti-ground)
+        - Ramp Buggy (anti-pod)
+        - Hacker Tank (specialist)
+        - Railgun Tank (anti-ground)
+
+        Aircraft:
+        - Assault Helicopter (anti-ground and anti-air)
+        - Turtle (anti-air)
+        - Banshee (anti-ground)
+
+        Navy:
+        - Light Boat (anti-ground and anti-air)
+        - Mercenary Boat (anti-ground)
+        - Laser Boat (anti-ground)
+        - Drone Ship (anti-ground)
+
+    Superunit:
+        - Mothership (anti-ground and anti-air)
+
+    Superweapons:
         - Drop Pods
         - Grand Howitzer
         - Thermonuclear Bomb
@@ -781,16 +822,16 @@ actor-jetpacker =
 
      Availability: Synapol
 
-actor-jetpacker2 =
+actor-jetfoiler =
    .description = Elite airborne vehicle.
     Armed with scatter gun.
       Strong vs Vehicles, Navy
       Weak vs Pods and Buildings
       Can't attack Aircraft
-   .name = Jetpacker2
+   .name = Jetfoiler
    .encyclopedia = The ultimate Yuruki pod: the jetpacker. It was designed for quick maneuverability and hit-and-run tactics to weaken Synapol's vehicle and navy forces. The fact that it's an airborne pod makes it less vulnerable to other pods.
 
-     {actor-jetpacker2.description}
+     {actor-jetfoiler.description}
 
      Availability: Yuruki
 
@@ -905,7 +946,7 @@ actor-submarine =
    .generic-name = Submarine
    .description = Submarine with powerful torpedoes.
       Strong vs Water
-      Can't attack Pods, Buildings, Vehicles or Air
+      Can't attack Pods, Buildings, Vehicles or Aircraft
    .encyclopedia = The submarine is a stealth ship, capable of going underwater. It has a torpedo launcher onboard than can take down a large ship in a few strike. It's slower than Yuruki's torpedo boat though.
 
      {actor-submarine.description}
@@ -942,7 +983,9 @@ actor-boomer =
    .name = Missile Submarine
    .generic-name = Submarine
    .description = A submarine with powerful long range missiles.
+   It excels destroying buildings.
       Strong vs Vehicles, Pods and Buildings
+      Can't attack Aircraft
    .encyclopedia = This heavy submarine is capable of launching ballistic missiles to a high range. As a submarine, it has the capability of going underwater.
 
      {actor-boomer.description}
@@ -953,7 +996,9 @@ actor-slcm-name = Submarine-launched cruise missile
 
 actor-carrier =
    .description = Launches aerial autonomous attack vessels.
+   It excels destroying buildings.
       Strong vs Vehicles, Pods and Buildings
+      Can't attack Aircraft
    .name = Drone Ship
    .encyclopedia = This heavy ship has a drone launch bay, containing three aerial autonomous drones, that can attack any target at a certain range. When a drone is shot down, it's reproduced. The drones have to reload themselves in the launch bay.
 
@@ -1002,8 +1047,9 @@ actor-mineship =
 actor-mbt =
    .name = Assault Tank
    .description = Main Battle Tank.
-      Strong vs Vehicles
+      Strong vs Vehicles and Buildings
       Weak vs Pods
+      Can't attack Aircraft
    .encyclopedia = Assault tanks are a great solution to deal against any other tank. Their turreted canon allow them to move at a decent speed, while still shooting down enemies. They also are decent against buildings, in groups.
 
      {actor-mbt.description}
@@ -1052,6 +1098,7 @@ actor-artillery =
    .description = Mobile long range weapon.
       Strong vs Pods and Buildings
       Weak vs Tanks
+      Can't attack Aircraft
    .encyclopedia = Armed with a long range artillery canon, this mobile artillery vehicle is extremely powerful against pods and buildings, while still being decently strong against other units. It was designed to power down enemies defenses while other units were assaulting a base.
 
      {actor-artillery.description}
@@ -1097,6 +1144,7 @@ actor-railguntank =
    .generic-name = Tank
    .description = A powerful tank which shoots laser.
       Strong vs Pods, Vehicles and Buildings
+      Can't attack Aircraft
    .encyclopedia = The railgun tank is the ultimate tank, able of handling every type of unit. It's armed with a powerful laser canon, and has a heavy armor.
 
      {actor-railguntank.description}
@@ -1105,7 +1153,9 @@ actor-railguntank =
 
 actor-lightningtank =
    .description = Fires electric discharges.
-      Strong vs Pods, Vehicles and Buildings
+      Strong Vehicles and Buildings
+      Weak vs Pods
+      Can't attack Aircraft
    .name = Lightning Tank
    .generic-name = Tank
    .encyclopedia = The lightning tank is the ultimate tank, able of handling every type of unit. It's armed with a powerful laser zap, and has a heavy armor.
@@ -1118,6 +1168,7 @@ actor-stealthtank =
    .description = Cloaked missile tank.
       Strong vs Vehicles and Buildings
       Weak vs Pods
+      Can't attack Aircraft
    .name = Stealth Tank
    .encyclopedia = The stealth tank is a modern tank, able of deploying a cloak on itself. It is armed with a powerful missile launcher, extremely powerful against buildings. It is yet less versatile than the lightning tank, it is stronger against buildings.
 
@@ -1131,6 +1182,7 @@ actor-merctank =
    .description = Main battle tank.
       Strong vs Vehicles
       Weak vs Pods
+      Can't attack Aircraft
    .encyclopedia = The mercenary tank is a generic tank, that can be only obtained through the drop zone buildings. Its canon cannot rotate like other battles tanks though.
 
      {actor-merctank.description}
@@ -1143,6 +1195,7 @@ actor-dualmerctank =
    .description = Double barreled tank.
       Strong vs Vehicles
       Weak vs Pods
+      Can't attack Aircraft
    .encyclopedia = Another variant of mercenary tank that can be only obtained through the drop zone buildings. Like the single barrelled variant its canon cannot rotate.
 
      {actor-dualmerctank.description}
@@ -1154,9 +1207,10 @@ actor-ecmtank =
    .generic-name = ECM Tank
    .description = Disables units for a brief moment.
       Jams incoming missiles.
+      Unarmed
    .encyclopedia = The electronic countermeasure (ECM) tank can overload enemy weaponry systems with a controlled beam that disables all electronic system units for a brief moment, disabling them completely. The effect only lasts a few seconds. Its other ability is to deflect incoming enemy missiles.
 
-     Unarmed
+     {actor-ecmtank.description}
 
      Availability: Yuruki
 
@@ -1164,6 +1218,7 @@ actor-dualartillery =
    .name = Dual Artillery
    .description = Double barreled artillery tank.
       Strong vs Pods, Vehicles and Buildings
+      Can't attack Aircraft
    .encyclopedia = This vehicle is an upgrade of the artillery tank. It's twice bigger, has more range, and fires two bombshells at once. Its range is extremely higher, and it's damaging against any type of armor. Due to intellectual property disputes, this design is rarely seen on the battlefield.
 
      {actor-dualartillery.description}
@@ -1178,7 +1233,7 @@ actor-builder =
    .name = Builder
    .encyclopedia = The builder is an important support unit, allowing the deployment of outpost which grants additional build radius, and allow base reconstruction.
 
-     Unarmed
+     {actor-builder.description}
 
      Availability: Universal/Faction design can vary
 
@@ -1190,7 +1245,7 @@ actor-miner =
    .name = Miner
    .encyclopedia = The role of this vehicle is to deploy mining facilities, allowing the production of resources, that are then transformed into cash at the storage building.
 
-     Unarmed
+     {actor-miner.description}
 
      Availability: Universal
 
@@ -1208,12 +1263,13 @@ actor-missiletank =
 
 actor-hackertank =
    .description = Temporarily changes allegiance of targeted units.
-      Disrupts satellite video links
-      and obscures the battlefield when deployed.
+    Disrupts satellite video links
+    and obscures the battlefield when deployed.
+      Unarmed
    .name = Hacker Tank
    .encyclopedia = The hacker tank contains equipment to penetrate firewalls of individual units and interfer with their command and control software so they will accept orders from the enemy and engage in friendly fire. The effective change of allegiance is permanent, until the hacker tank gets destroyed or changes the target. It can only have one controlled unit at a time. Its other ability is to disrupt satellite video links, blocking field detection in the radar.
 
-     Unarmed
+     {actor-ecmtank.description}
 
      Availability: Synapol
 
@@ -1223,6 +1279,7 @@ actor-buggy =
    .description = Fires a machine gun.
       Strong vs Pods
       Weak vs Tanks, Buildings
+      Can't attack Aircraft
    .encyclopedia = The ramp buggy is a fast anti-pod vehicle, that has a turret heavy machine gun, capable of destroying a group of pods by itself. It is Synapol's solution to the Yuruki gatling bike: while it is slower, its machine gun is turreted, giving it an advantage.
 
      {actor-buggy.description}
@@ -1235,6 +1292,7 @@ actor-bike =
    .description = Fires a machine gun.
       Strong vs Pods
       Weak vs Tanks, Buildings
+      Can't attack Aircraft
    .encyclopedia = The gatling bike is a fast anti-pod vehicle, that has a powerful heavy machine gun, capable of destroying a group of pods by itself.
 
      {actor-bike.description}
@@ -1268,7 +1326,8 @@ actor-cvit =
 
 actor-mothership =
    .name = Mothership
-   .description = Launches aerial autonomous attack vessels.
+   .description = Launches anti-air aerial autonomous
+    attack vessels and has powerful anti-ground lasers.
       Only one can be built.
       Strong vs Everything
    .encyclopedia = When the Yuruki colony on Mars started their battleship design program, the Synapol Corporations had to design themselves a massive air unit to counter the battleship. The mothership was their solution. It's a real floating city: it regroups a crew of 2,500 men, and has many different quarters, some being science labs, other armament testing... It is armed with four powerful plasma turreted canon that can target ground structures, and with a drone bay, containing five of them. When a drone is destroyed, another one is immediately reproduced.

--- a/mods/hv/fluent/rules.ftl
+++ b/mods/hv/fluent/rules.ftl
@@ -19,22 +19,17 @@ faction-yuruki =
     Their colonial defense forces helped pave the way for
     an aggressive expansion throughout the solar system.
 
-    Faction Variations:
-        - Uses fighter jets as air units
+    Strategy:
+        - Focuses on stealth and specialized combat units
+        - Transport and aerial scout units are faster but
+          less resistant
 
-    Special Units:
-        - Shocker Pod
-        - Blaster Pod
-        - Sniper Pod
-        - Gatling Bike
-        - Hacker Tank
-        - Lightning Tank
-        - Stealth Tank
-        - Battleship
+    Superunit:
+        - Battleship (anti-ground)
 
-    Superweapon:
+    Superweapons:
         - Air Strike
-        - Field Generator
+        - Force Field Generator
         - Orbital Railgun Strike
 
 faction-synapol =
@@ -44,21 +39,15 @@ faction-synapol =
     everything from common household appliances to armaments.
     Their security department became a large paramilitary force.
 
-    Faction Variations:
-        - Uses helicopters as air units
-        - Uses submarines as advanced naval units
+    Strategy:
+        - Focuses on brute force and flexible combat units
+        - Transport and aerial scout units are slower but
+          more resistant
 
-    Special Units:
-        - Rocketeer Pod
-        - Flamer Pod
-        - Mortar Pod
-        - Ramp Buggy
-        - Countermeasure Tank
-        - Railgun Tank
-        - Missile Tank
-        - Mothership
+    Superunit:
+        - Mothership (anti-ground and anti-air)
 
-    Superweapon:
+    Superweapons:
         - Drop Pods
         - Grand Howitzer
         - Thermonuclear Bomb
@@ -781,16 +770,16 @@ actor-jetpacker =
 
      Availability: Synapol
 
-actor-jetpacker2 =
+actor-jetfoiler =
    .description = Elite airborne vehicle.
     Armed with scatter gun.
       Strong vs Vehicles, Navy
       Weak vs Pods and Buildings
       Can't attack Aircraft
-   .name = Jetpacker2
+   .name = Jetfoiler
    .encyclopedia = The ultimate Yuruki pod: the jetpacker. It was designed for quick maneuverability and hit-and-run tactics to weaken Synapol's vehicle and navy forces. The fact that it's an airborne pod makes it less vulnerable to other pods.
 
-     {actor-jetpacker2.description}
+     {actor-jetfoiler.description}
 
      Availability: Yuruki
 
@@ -905,7 +894,7 @@ actor-submarine =
    .generic-name = Submarine
    .description = Submarine with powerful torpedoes.
       Strong vs Water
-      Can't attack Pods, Buildings, Vehicles or Air
+      Can't attack Pods, Buildings, Vehicles or Aircraft
    .encyclopedia = The submarine is a stealth ship, capable of going underwater. It has a torpedo launcher onboard than can take down a large ship in a few strike. It's slower than Yuruki's torpedo boat though.
 
      {actor-submarine.description}
@@ -942,7 +931,9 @@ actor-boomer =
    .name = Missile Submarine
    .generic-name = Submarine
    .description = A submarine with powerful long range missiles.
+   It excels destroying buildings.
       Strong vs Vehicles, Pods and Buildings
+      Can't attack Aircraft
    .encyclopedia = This heavy submarine is capable of launching ballistic missiles to a high range. As a submarine, it has the capability of going underwater.
 
      {actor-boomer.description}
@@ -953,7 +944,9 @@ actor-slcm-name = Submarine-launched cruise missile
 
 actor-carrier =
    .description = Launches aerial autonomous attack vessels.
+   It excels destroying buildings.
       Strong vs Vehicles, Pods and Buildings
+      Can't attack Aircraft
    .name = Drone Ship
    .encyclopedia = This heavy ship has a drone launch bay, containing three aerial autonomous drones, that can attack any target at a certain range. When a drone is shot down, it's reproduced. The drones have to reload themselves in the launch bay.
 
@@ -1002,8 +995,9 @@ actor-mineship =
 actor-mbt =
    .name = Assault Tank
    .description = Main Battle Tank.
-      Strong vs Vehicles
+      Strong vs Vehicles and Buildings
       Weak vs Pods
+      Can't attack Aircraft
    .encyclopedia = Assault tanks are a great solution to deal against any other tank. Their turreted canon allow them to move at a decent speed, while still shooting down enemies. They also are decent against buildings, in groups.
 
      {actor-mbt.description}
@@ -1052,6 +1046,7 @@ actor-artillery =
    .description = Mobile long range weapon.
       Strong vs Pods and Buildings
       Weak vs Tanks
+      Can't attack Aircraft
    .encyclopedia = Armed with a long range artillery canon, this mobile artillery vehicle is extremely powerful against pods and buildings, while still being decently strong against other units. It was designed to power down enemies defenses while other units were assaulting a base.
 
      {actor-artillery.description}
@@ -1097,6 +1092,7 @@ actor-railguntank =
    .generic-name = Tank
    .description = A powerful tank which shoots laser.
       Strong vs Pods, Vehicles and Buildings
+      Can't attack Aircraft
    .encyclopedia = The railgun tank is the ultimate tank, able of handling every type of unit. It's armed with a powerful laser canon, and has a heavy armor.
 
      {actor-railguntank.description}
@@ -1105,7 +1101,9 @@ actor-railguntank =
 
 actor-lightningtank =
    .description = Fires electric discharges.
-      Strong vs Pods, Vehicles and Buildings
+      Strong Vehicles and Buildings
+      Weak vs Pods
+      Can't attack Aircraft
    .name = Lightning Tank
    .generic-name = Tank
    .encyclopedia = The lightning tank is the ultimate tank, able of handling every type of unit. It's armed with a powerful laser zap, and has a heavy armor.
@@ -1118,6 +1116,7 @@ actor-stealthtank =
    .description = Cloaked missile tank.
       Strong vs Vehicles and Buildings
       Weak vs Pods
+      Can't attack Aircraft
    .name = Stealth Tank
    .encyclopedia = The stealth tank is a modern tank, able of deploying a cloak on itself. It is armed with a powerful missile launcher, extremely powerful against buildings. It is yet less versatile than the lightning tank, it is stronger against buildings.
 
@@ -1131,6 +1130,7 @@ actor-merctank =
    .description = Main battle tank.
       Strong vs Vehicles
       Weak vs Pods
+      Can't attack Aircraft
    .encyclopedia = The mercenary tank is a generic tank, that can be only obtained through the drop zone buildings. Its canon cannot rotate like other battles tanks though.
 
      {actor-merctank.description}
@@ -1143,6 +1143,7 @@ actor-dualmerctank =
    .description = Double barreled tank.
       Strong vs Vehicles
       Weak vs Pods
+      Can't attack Aircraft
    .encyclopedia = Another variant of mercenary tank that can be only obtained through the drop zone buildings. Like the single barrelled variant its canon cannot rotate.
 
      {actor-dualmerctank.description}
@@ -1154,9 +1155,10 @@ actor-ecmtank =
    .generic-name = ECM Tank
    .description = Disables units for a brief moment.
       Jams incoming missiles.
+      Unarmed
    .encyclopedia = The electronic countermeasure (ECM) tank can overload enemy weaponry systems with a controlled beam that disables all electronic system units for a brief moment, disabling them completely. The effect only lasts a few seconds. Its other ability is to deflect incoming enemy missiles.
 
-     Unarmed
+     {actor-ecmtank.description}
 
      Availability: Yuruki
 
@@ -1164,6 +1166,7 @@ actor-dualartillery =
    .name = Dual Artillery
    .description = Double barreled artillery tank.
       Strong vs Pods, Vehicles and Buildings
+      Can't attack Aircraft
    .encyclopedia = This vehicle is an upgrade of the artillery tank. It's twice bigger, has more range, and fires two bombshells at once. Its range is extremely higher, and it's damaging against any type of armor. Due to intellectual property disputes, this design is rarely seen on the battlefield.
 
      {actor-dualartillery.description}
@@ -1178,7 +1181,7 @@ actor-builder =
    .name = Builder
    .encyclopedia = The builder is an important support unit, allowing the deployment of outpost which grants additional build radius, and allow base reconstruction.
 
-     Unarmed
+     {actor-builder.description}
 
      Availability: Universal/Faction design can vary
 
@@ -1190,7 +1193,7 @@ actor-miner =
    .name = Miner
    .encyclopedia = The role of this vehicle is to deploy mining facilities, allowing the production of resources, that are then transformed into cash at the storage building.
 
-     Unarmed
+     {actor-miner.description}
 
      Availability: Universal
 
@@ -1208,12 +1211,13 @@ actor-missiletank =
 
 actor-hackertank =
    .description = Temporarily changes allegiance of targeted units.
-      Disrupts satellite video links
-      and obscures the battlefield when deployed.
+    Disrupts satellite video links
+    and obscures the battlefield when deployed.
+      Unarmed
    .name = Hacker Tank
    .encyclopedia = The hacker tank contains equipment to penetrate firewalls of individual units and interfer with their command and control software so they will accept orders from the enemy and engage in friendly fire. The effective change of allegiance is permanent, until the hacker tank gets destroyed or changes the target. It can only have one controlled unit at a time. Its other ability is to disrupt satellite video links, blocking field detection in the radar.
 
-     Unarmed
+     {actor-ecmtank.description}
 
      Availability: Synapol
 
@@ -1223,6 +1227,7 @@ actor-buggy =
    .description = Fires a machine gun.
       Strong vs Pods
       Weak vs Tanks, Buildings
+      Can't attack Aircraft
    .encyclopedia = The ramp buggy is a fast anti-pod vehicle, that has a turret heavy machine gun, capable of destroying a group of pods by itself. It is Synapol's solution to the Yuruki gatling bike: while it is slower, its machine gun is turreted, giving it an advantage.
 
      {actor-buggy.description}
@@ -1235,6 +1240,7 @@ actor-bike =
    .description = Fires a machine gun.
       Strong vs Pods
       Weak vs Tanks, Buildings
+      Can't attack Aircraft
    .encyclopedia = The gatling bike is a fast anti-pod vehicle, that has a powerful heavy machine gun, capable of destroying a group of pods by itself.
 
      {actor-bike.description}
@@ -1268,7 +1274,8 @@ actor-cvit =
 
 actor-mothership =
    .name = Mothership
-   .description = Launches aerial autonomous attack vessels.
+   .description = Launches anti-air aerial autonomous
+    attack vessels and has powerful anti-ground lasers.
       Only one can be built.
       Strong vs Everything
    .encyclopedia = When the Yuruki colony on Mars started their battleship design program, the Synapol Corporations had to design themselves a massive air unit to counter the battleship. The mothership was their solution. It's a real floating city: it regroups a crew of 2,500 men, and has many different quarters, some being science labs, other armament testing... It is armed with four powerful plasma turreted canon that can target ground structures, and with a drone bay, containing five of them. When a drone is destroyed, another one is immediately reproduced.

--- a/mods/hv/mod.yaml
+++ b/mods/hv/mod.yaml
@@ -2,7 +2,7 @@
 
 Metadata:
 	Title: mod-title
-	Version: {DEV_VERSION}
+	Version: git-8bb01f49
 	Website: https://www.openhv.net
 	WebIcon32: https://www.openhv.net/images/web/icon.png
 	WindowTitle: mod-windowtitle
@@ -53,7 +53,7 @@ FileSystem: DefaultFileSystem
 
 MapFolders:
 	hv|maps: System
-	~^SupportDir|maps/hv/{DEV_VERSION}: User
+	~^SupportDir|maps/hv/git-8bb01f49: User
 
 Rules:
 	hv|rules/editor.yaml

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -1052,6 +1052,7 @@ MOTHERSHIP:
 		CruiseAltitude: 3c0
 		AltitudeVelocity: 0c56
 		InitialFacing: 512
+		RepulsionSpeed: -1
 	HitShape:
 		Type: Circle
 			Radius: 1024
@@ -1202,6 +1203,7 @@ BATTLESHIP:
 		CruiseAltitude: 3c0
 		AltitudeVelocity: 0c56
 		InitialFacing: 512
+		RepulsionSpeed: -1
 	HitShape:
 		Type: Circle
 			Radius: 1024

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -603,7 +603,7 @@ CHOPPER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 49500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -615,8 +615,8 @@ CHOPPER:
 		Range: 4c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 20
-		Speed: 135
+		TurnSpeed: 18
+		Speed: 122
 		AltitudeVelocity: 0c58
 		LandAltitude: 0c0
 		LandableTerrainTypes: Clear, Ore, Crater, Road, Grass, Grass Pit, Mountain, Snow, Red Snow, Sand, Black Sand, Stone, Tech, Rail, Blocked, Dirt
@@ -631,17 +631,11 @@ CHOPPER:
 	Selectable:
 		DecorationBounds: 2048, 1843
 	Cargo:
-		Types: Pod
+		Types: Pod, Vehicle
 		MaxWeight: 8
-		AfterUnloadDelay: 40
+		AfterUnloadDelay: 0
 		RequiresCondition: !carrying
 		LoadedCondition: loaded
-	Carryall:
-		BeforeLoadDelay: 10
-		BeforeUnloadDelay: 10
-		LocalOffset: 0,0,-200
-		CarryCondition: carrying
-		RequiresCondition: !loaded
 	WithCargoPipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3
@@ -769,7 +763,7 @@ DROPSHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 40500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -781,10 +775,10 @@ DROPSHIP:
 		Range: 4c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 20
-		Speed: 135
-		LandAltitude: 0c0
+		TurnSpeed: 22
+		Speed: 149
 		AltitudeVelocity: 0c58
+		LandAltitude: 0c0
 		InitialFacing: 512
 		LandableTerrainTypes: Clear, Ore, Crater, Road, Grass, Grass Pit, Mountain, Snow, Red Snow, Sand, Black Sand, Stone, Tech, Rail, Blocked, Dirt
 	Voiced:
@@ -798,20 +792,9 @@ DROPSHIP:
 	Selectable:
 		DecorationBounds: 2048, 1848
 	Cargo:
-		Types: Pod
+		Types: Pod, Vehicle
 		MaxWeight: 8
-		AfterUnloadDelay: 40
-		UnloadVoice: Unload
-		RequiresCondition: !carrying
-		LoadedCondition: loaded
-	Carryall:
-		BeforeLoadDelay: 10
-		BeforeUnloadDelay: 10
-		LocalOffset: 0,0,-200
-		Voice: Unload
-		PickUpCursor: enter
-		CarryCondition: carrying
-		RequiresCondition: !loaded
+		AfterUnloadDelay: 0
 	WithCargoPipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -2,78 +2,16 @@
 
 GUNSHIP:
 	Inherits: ^Plane
-	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
-	Inherits@MagazineCasing: ^DropShellCasing
-	Inherits@Smoke: ^SmokeEmitter
-	Buildable:
-		Queue: Aircraft
-		BuildPaletteOrder: 30
-		Prerequisites: ~starport.yi
-		Description: actor-gunship.description
-	Encyclopedia:
-		Description: actor-gunship.encyclopedia
-		Order: 2
-		Scale: 3
-		Category: Aircraft
-	Valued:
-		Cost: 2000
-	Tooltip:
-		Name: actor-gunship.name
-	UpdatesPlayerStatistics:
-		AddToArmyValue: true
-	Health:
-		HP: 10000
-	RevealsShroud:
-		Range: 10c0
-		MinRange: 4c0
-		Type: GroundPosition
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 4c0
-		Type: GroundPosition
-	Armament@Ground:
-		Weapon: AircraftChainGunGround
-		MuzzleSequence: muzzle
-		LocalOffset: 300,0,0
-	Armament@Air:
-		Weapon: AircraftChainGunAir
-		MuzzleSequence: muzzle
-		LocalOffset: 300,0,0
-	AttackAircraft:
-		FacingTolerance: 92
-		PersistentTargeting: false
-		OpportunityFire: false
-	Aircraft:
-		CruiseAltitude: 2c512
-		InitialFacing: 768
-		TurnSpeed: 20
-		Speed: 200
-		RepulsionSpeed: 40
-		MaximumPitch: 56
-	Voiced:
-		VoiceSet: GunshipVoice
-	AutoTarget:
-		InitialStance: Defend
-		InitialStanceAI: AttackAnything
-	AutoTargetPriority:
-		InvalidTargets: Structure
-	WithMuzzleOverlay:
-	Contrail@Right:
-		Offset: -420,-264,0
-		TrailLength: 12
-	Contrail@Left:
-		Offset: -420,264,0
-		TrailLength: 12
-	Selectable:
-		Bounds: 1024, 1024
-
-GUNSHIP2:
-	Inherits: ^Helicopter
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Inherits@MagazineCasing: ^DropShellCasing
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
 		Cost: 2000
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 15000
+	RevealsShroud:
 	Tooltip:
 		Name: actor-gunship.name
 	Buildable:
@@ -88,8 +26,6 @@ GUNSHIP2:
 		Category: Aircraft
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
-	Health:
-		HP: 10000
 	RevealsShroud:
 		Range: 10c0
 		MinRange: 4c0
@@ -100,12 +36,13 @@ GUNSHIP2:
 		Type: GroundPosition
 	Aircraft:
 		TurnSpeed: 20
-		Speed: 115
+		Speed: 200
 	Voiced:
 		VoiceSet: GunshipVoice
-	AttackFrontal:
-		RequiresCondition: airborne
-		FacingTolerance: 8
+	AttackAircraft:
+		FacingTolerance: 92
+		PersistentTargeting: false
+		OpportunityFire: false
 	Armament@Ground:
 		Name: primary
 		Weapon: HelicopterChainGunGround
@@ -113,6 +50,68 @@ GUNSHIP2:
 	Armament@Air:
 		Name: secondary
 		Weapon: HelicopterChainGunAir
+		LocalOffset: 50,0,0
+	Selectable:
+		Bounds: 1228, 1228
+	Contrail@Right:
+		Offset: -620,-130,0
+		TrailLength: 10
+		ZOffset: -64
+	Contrail@Left:
+		Offset: -620,130,0
+		TrailLength: 10
+		ZOffset: -64
+
+GUNSHIP2:
+	Inherits: ^Hovercraft
+	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
+	Inherits@MagazineCasing: ^DropShellCasing
+	Inherits@Smoke: ^SmokeEmitter
+	Valued:
+		Cost: 1500
+	Tooltip:
+		Name: actor-gunship.name
+	Buildable:
+		Queue: Aircraft
+		BuildPaletteOrder: 30
+		Prerequisites: ~starport.yi
+		Description: actor-gunship.description
+	Encyclopedia:
+		Description: actor-gunship.encyclopedia
+		Order: 2
+		Scale: 3
+		Category: Aircraft
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Health:
+		HP: 15000
+	RevealsShroud:
+		Range: 10c0
+		MinRange: 5c0
+		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 5c0
+		Type: GroundPosition
+	Aircraft:
+		CruiseAltitude: 2c512
+		InitialFacing: 768
+		TurnSpeed: 20
+		Speed: 200
+		RepulsionSpeed: 40
+		MaximumPitch: 56
+	Voiced:
+		VoiceSet: GunshipVoice
+	AttackFrontal:
+		RequiresCondition: airborne
+		FacingTolerance: 32
+	Armament@Ground:
+		Name: primary
+		Weapon: AircraftChainGunGround
+		LocalOffset: 50,0,0
+	Armament@Air:
+		Name: secondary
+		Weapon: AircraftChainGunAir
 		LocalOffset: 50,0,0
 	Selectable:
 		Bounds: 1228, 1228
@@ -131,37 +130,48 @@ GUNSHIP2:
 		ZOffset: -64
 
 GUNSHIP3:
-	Inherits: ^Helicopter
+	Inherits: ^Hovercraft
+	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Inherits@Smoke: ^SmokeEmitter
-	Valued:
-		Cost: 3000
-	Tooltip:
-		Name: actor-gunship3.name
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 55
-		Prerequisites: ~disabled
+		Prerequisites: techcenter, ~starport.yi
 		Description: actor-gunship3.description
 	Encyclopedia:
 		Description: actor-gunship3.encyclopedia
 		Order: 10
 		Scale: 3
 		Category: Aircraft
+	Valued:
+		Cost: 2500
+	Tooltip:
+		Name: actor-gunship3.name
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 22500
 	RevealsShroud:
 		Range: 11c0
-		MinRange: 4c0
+		MinRange: 5c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 5c0
 		Type: GroundPosition
+	Armament:
+		Weapon: Plasma
+		LocalOffset: 750,-400,0, 750,400,0
+	AttackFrontal:
+		RequiresCondition: airborne
+		FacingTolerance: 8
 	Aircraft:
+		CruiseAltitude: 2c512
+		InitialFacing: 768
 		TurnSpeed: 20
-		Speed: 112
+		Speed: 155
+		RepulsionSpeed: 40
+		MaximumPitch: 56
 	Voiced:
 		VoiceSet: SpeederVoice
 	AutoTarget:
@@ -169,35 +179,30 @@ GUNSHIP3:
 		InitialStanceAI: AttackAnything
 	AutoTargetPriority:
 		InvalidTargets: Structure
-	AttackFrontal:
-		RequiresCondition: airborne
-		FacingTolerance: 8
 	Selectable:
 		Bounds: 1228, 1228
-	Armament:
-		Weapon: Plasma
-		LocalOffset: 750,-400,0, 750,400,0
-		PauseOnCondition: !ammo
-	AmmoPool:
-		Ammo: 8
-		AmmoCondition: ammo
-	WithAmmoPipsDecoration:
-		Position: BottomLeft
-		Margin: 4, 3
-		RequiresSelection: true
-		PipCount: 8
-	ReloadAmmoPool:
-		Delay: 100
-		Count: 1
+	Cloak:
+		InitialDelay: 250
+		CloakDelay: 250
+		CloakSound: stealth_on_humanoide9000.ogg
+		UncloakSound: stealth_off_humanoide9000.ogg
+		UncloakOn: Attack, Unload
+		IsPlayerPalette: true
+		PauseOnCondition: cloak-force-disabled
+		CloakedPalette: cloak
+		CloakStyle: Palette
+	GrantConditionOnDamageState@UNCLOAK:
+		Condition: cloak-force-disabled
+		ValidDamageStates: Critical
 
 JET:
-	Inherits: ^Plane
+	Inherits: ^Hovercraft
 	Inherits@AutoTarget: ^AutoTargetAirAssaultMove
 	Inherits@Smoke: ^SmokeEmitter
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 50
-		Prerequisites: techcenter, ~starport.yi
+		Prerequisites: ~starport.yi
 		Description: actor-jet.description
 	Encyclopedia:
 		Description: actor-jet.encyclopedia
@@ -205,32 +210,32 @@ JET:
 		Scale: 3
 		Category: Aircraft
 	Valued:
-		Cost: 1500
+		Cost: 2000
 	Tooltip:
 		Name: actor-jet.name
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 24000
 	RevealsShroud:
 		Range: 11c0
-		MinRange: 4c0
+		MinRange: 5c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 5c0
 		Type: GroundPosition
 	Armament:
 		Weapon: PlasmaMachineGun
 		LocalOffset: 500,-200,0, 500,200,0
 	AttackAircraft:
-		FacingTolerance: 100
+		FacingTolerance: 32
 		PersistentTargeting: false
 		OpportunityFire: false
 	Aircraft:
 		CruiseAltitude: 2c512
 		InitialFacing: 768
-		TurnSpeed: 40
+		TurnSpeed: 22
 		Speed: 220
 		RepulsionSpeed: 40
 		MaximumPitch: 56
@@ -257,7 +262,7 @@ JET2:
 	Buildable:
 		Queue: Aircraft
 		BuildPaletteOrder: 55
-		Prerequisites: techcenter, ~starport.yi
+		Prerequisites: ~disabled
 		Description: actor-jet2.description
 	Encyclopedia:
 		Description: actor-jet2.encyclopedia
@@ -265,20 +270,20 @@ JET2:
 		Scale: 3
 		Category: Aircraft
 	Valued:
-		Cost: 3000
+		Cost: 2500
 	Tooltip:
 		Name: actor-jet2.name
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 22500
 	RevealsShroud:
 		Range: 11c0
-		MinRange: 4c0
+		MinRange: 5c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 5c0
 		Type: GroundPosition
 	Armament:
 		Weapon: Plasma
@@ -287,25 +292,21 @@ JET2:
 	AmmoPool:
 		Ammo: 8
 		AmmoCondition: ammo
+	ReloadAmmoPool:
+		Delay: 100
+		Count: 1
 	WithAmmoPipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3
 		RequiresSelection: true
 		PipCount: 8
-	ReloadAmmoPool:
-		Delay: 100
-		Count: 1
 	AttackAircraft:
 		FacingTolerance: 92
 		PersistentTargeting: false
 		OpportunityFire: false
 	Aircraft:
-		CruiseAltitude: 2c512
-		InitialFacing: 768
 		TurnSpeed: 20
-		Speed: 155
-		RepulsionSpeed: 40
-		MaximumPitch: 56
+		Speed: 115
 	Voiced:
 		VoiceSet: SpeederVoice
 	AutoTarget:
@@ -336,7 +337,7 @@ COPTER:
 	Inherits@MagazineCasing: ^DropShellCasing
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 2000
+		Cost: 1500
 	Tooltip:
 		Name: actor-copter.name
 	Buildable:
@@ -352,14 +353,14 @@ COPTER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 10000
+		HP: 15000
 	RevealsShroud:
-		Range: 10c0
-		MinRange: 4c0
+		Range: 12c0
+		MinRange: 6c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
 		TurnSpeed: 20
@@ -371,13 +372,13 @@ COPTER:
 		Offset: 200,0,-100
 	AttackTurreted:
 		RequiresCondition: airborne
-	Armament@Ground:
+	Armament@Primary:
+		Name: primary
 		Weapon: HelicopterChainGunGround
-		MuzzleSequence: muzzle
 		LocalOffset: 50,0,0
-	Armament@Air:
+	Armament@Secondary:
+		Name: secondary
 		Weapon: HelicopterChainGunAir
-		MuzzleSequence: muzzle
 		LocalOffset: 50,0,0
 	Selectable:
 		Bounds: 1228, 1228
@@ -402,7 +403,7 @@ SAUCER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 8000
+		HP: 12000
 	RevealsShroud:
 		Range: 18c0
 		MinRange: 9c0
@@ -445,18 +446,18 @@ OBSERVER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 8000
+		HP: 12000
 	RevealsShroud:
-		Range: 18c0
-		MinRange: 9c0
+		Range: 20c0
+		MinRange: 10c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 9c0
+		Range: 10c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 50
-		Speed: 80
+		TurnSpeed: 45
+		Speed: 70
 		CanForceLand: false
 		LandableTerrainTypes: Clear, Ore, Crater, Road, Grass, Grass Pit, Mountain, Snow, Red Snow, Sand, Black Sand, Stone, Tech, Rail, Blocked, Dirt
 	Voiced:
@@ -475,12 +476,12 @@ BANSHEE:
 	Inherits@Smoke: ^SmokeEmitter
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 3000
+		Cost: 2500
 	Tooltip:
 		Name: actor-banshee.name
 	Buildable:
 		Queue: Aircraft
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 55
 		Prerequisites: techcenter, ~starport.sc
 		Description: actor-banshee.description
 	Encyclopedia:
@@ -491,14 +492,14 @@ BANSHEE:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 27500
 	RevealsShroud:
-		Range: 11c0
-		MinRange: 4c0
+		Range: 12c0
+		MinRange: 6c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
 		TurnSpeed: 20
@@ -511,19 +512,7 @@ BANSHEE:
 	Armament:
 		Weapon: ShipMissile
 		LocalOffset: 500,225,0, 500,-225,0
-		PauseOnCondition: !ammo
 		MuzzleSequence: muzzle
-	AmmoPool:
-		Ammo: 6
-		AmmoCondition: ammo
-	WithAmmoPipsDecoration:
-		Position: BottomLeft
-		Margin: 4, 3
-		RequiresSelection: true
-		PipCount: 6
-	ReloadAmmoPool:
-		Delay: 100
-		Count: 1
 	Selectable:
 		DecorationBounds: 1228, 1228
 	WithMuzzleOverlay:
@@ -533,13 +522,13 @@ TURTLE:
 	Inherits@AutoTarget: ^AutoTargetAirAssaultMove
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 1500
+		Cost: 2000
 	Tooltip:
 		Name: actor-turtle.name
 	Buildable:
 		Queue: Aircraft
-		BuildPaletteOrder: 55
-		Prerequisites: techcenter, ~starport.sc
+		BuildPaletteOrder: 50
+		Prerequisites: ~starport.sc
 		Description: actor-turtle.description
 	Encyclopedia:
 		Description: actor-turtle.encyclopedia
@@ -549,18 +538,18 @@ TURTLE:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 30000
+		HP: 25000
 	RevealsShroud:
-		Range: 10c0
-		MinRange: 4c0
+		Range: 11c0
+		MinRange: 5c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 5c0
 		Type: GroundPosition
 	Aircraft:
-		TurnSpeed: 40
-		Speed: 100
+		TurnSpeed: 22
+		Speed: 127
 	Voiced:
 		VoiceSet: TurtleVoice
 	Turreted:
@@ -571,7 +560,6 @@ TURTLE:
 	Armament:
 		Weapon: DiscThrower
 		LocalOffset: 0,0,0
-		FireDelay: 2
 	Selectable:
 		Bounds: 1400, 1400
 	WithMoveAnimation:
@@ -603,7 +591,7 @@ CHOPPER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 49500
+		HP: 74250
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -634,8 +622,6 @@ CHOPPER:
 		Types: Pod, Vehicle
 		MaxWeight: 8
 		AfterUnloadDelay: 0
-		RequiresCondition: !carrying
-		LoadedCondition: loaded
 	WithCargoPipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3
@@ -716,17 +702,18 @@ BALLOON:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 8000
+		HP: 10800
 	RevealsShroud:
-		Range: 20c0
-		MinRange: 10c0
+		Range: 18c0
+		MinRange: 9c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 10c0
+		Range: 9c0
 		Type: GroundPosition
 	Aircraft:
-		Speed: 70
+		TurnSpeed: 50
+		Speed: 80
 		CanForceLand: false
 		LandableTerrainTypes: Clear, Ore, Crater, Road, Grass, Grass Pit, Mountain, Snow, Red Snow, Sand, Black Sand, Stone, Tech, Rail, Blocked, Dirt
 	Voiced:
@@ -763,7 +750,7 @@ DROPSHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 40500
+		HP: 60750
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -856,93 +843,50 @@ DROPSHIP.Husk:
 		Image: dropship
 
 DRONE:
-	Inherits: ^SpawnedPlane
-	Valued:
-		Cost: 100
+	Inherits: ^BaseDrone
 	Tooltip:
 		Name: actor-drone-name
 	Health:
-		HP: 5000
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 4c0
-		MinRange: 2c0
-		Type: GroundPosition
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 2c0
-		Type: GroundPosition
+		HP: 7500
 	Armament:
 		Weapon: DroneBlaster
-		PauseOnCondition: !ammo
 	WithAttackAnimation:
 		Sequence: shoot
 	Aircraft:
 		Speed: 250
-		AltitudeVelocity: 240
-		VTOL: true
-		Repulsable: false
-		LandAltitude: 0c0
 	AttackAircraft:
 		FacingTolerance: 92
 		Voice: Attack
-	AmmoPool:
-		Ammo: 5
-		AmmoCondition: ammo
 	CarrierChild:
 		LandingDistance: 8c0
 	Rearmable:
 		RearmActors: carrier
-	-MapEditorData:
 
 DRONE2:
-	Inherits: ^SpawnedPlane
-	Valued:
-		Cost: 100
+	Inherits: ^BaseDrone
 	Tooltip:
 		Name: actor-drone2.name
 	Health:
-		HP: 7500
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 4c0
-		MinRange: 2c0
-		Type: GroundPosition
-		RevealGeneratedShroud: False
-	RevealsShroud@Hacked:
-		Range: 2c0
-		Type: GroundPosition
+		HP: 11250
 	Armament:
 		Weapon: DronePulseGun
 		MuzzleSequence: muzzle
 		LocalOffset: -75,75,0, -75,-75,0
-		PauseOnCondition: !ammo
 	Aircraft:
 		Speed: 200
-		AltitudeVelocity: 240
-		VTOL: true
-		Repulsable: false
-		LandAltitude: 0c0
 	AttackAircraft:
 		FacingTolerance: 256
 		Voice: Attack
-	AmmoPool:
-		Ammo: 250
-		ReloadCount: 15
-		AmmoCondition: ammo
 	CarrierChild:
 		LandingDistance: 16c0
 	Rearmable:
 		RearmActors: mothership
 	WithMuzzleOverlay:
-	-MapEditorData:
 
 DROPPOD1:
 	Inherits: ^DropPod
 	SpawnActorOnDeath:
-		Actor: rifleman
+		Actor: mortar
 	-MapEditorData:
 
 DROPPOD2:
@@ -971,7 +915,7 @@ LANDEDPOD:
 		StartIfBelow: 101
 		Delay: 6
 	Health:
-		HP: 10000
+		HP: 15000
 	Tooltip:
 		Name: actor-landedpod-name
 	HitShape:
@@ -1074,7 +1018,7 @@ MOTHERSHIP:
 	Inherits@Smoke: ^SmokeEmitter
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 12000
+		Cost: 15000
 	Tooltip:
 		Name: actor-mothership.name
 	Buildable:
@@ -1091,7 +1035,7 @@ MOTHERSHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 250000
+		HP: 375000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -1224,7 +1168,7 @@ BATTLESHIP:
 	Inherits@Smoke: ^SmokeEmitter
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 12000
+		Cost: 15000
 	Tooltip:
 		Name: actor-battleship.name
 	Buildable:
@@ -1241,7 +1185,7 @@ BATTLESHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 250000
+		HP: 375000
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -6,7 +6,7 @@ GUNSHIP:
 	Inherits@MagazineCasing: ^DropShellCasing
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 2000
+		Cost: 4000
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
@@ -68,7 +68,7 @@ GUNSHIP2:
 	Inherits@MagazineCasing: ^DropShellCasing
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 1500
+		Cost: 3000
 	Tooltip:
 		Name: actor-gunship.name
 	Buildable:
@@ -144,7 +144,7 @@ GUNSHIP3:
 		Scale: 3
 		Category: Aircraft
 	Valued:
-		Cost: 2500
+		Cost: 5000
 	Tooltip:
 		Name: actor-gunship3.name
 	UpdatesPlayerStatistics:
@@ -210,7 +210,7 @@ JET:
 		Scale: 3
 		Category: Aircraft
 	Valued:
-		Cost: 2000
+		Cost: 4000
 	Tooltip:
 		Name: actor-jet.name
 	UpdatesPlayerStatistics:
@@ -270,7 +270,7 @@ JET2:
 		Scale: 3
 		Category: Aircraft
 	Valued:
-		Cost: 2500
+		Cost: 5000
 	Tooltip:
 		Name: actor-jet2.name
 	UpdatesPlayerStatistics:
@@ -337,7 +337,7 @@ COPTER:
 	Inherits@MagazineCasing: ^DropShellCasing
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 1500
+		Cost: 3000
 	Tooltip:
 		Name: actor-copter.name
 	Buildable:
@@ -387,7 +387,7 @@ COPTER:
 SAUCER:
 	Inherits: ^Helicopter
 	Valued:
-		Cost: 800
+		Cost: 1200
 	Tooltip:
 		Name: actor-saucer.name
 	Buildable:
@@ -430,7 +430,7 @@ SAUCER:
 OBSERVER:
 	Inherits: ^Helicopter
 	Valued:
-		Cost: 800
+		Cost: 1200
 	Tooltip:
 		Name: actor-observer.name
 	Buildable:
@@ -476,7 +476,7 @@ BANSHEE:
 	Inherits@Smoke: ^SmokeEmitter
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 2500
+		Cost: 5000
 	Tooltip:
 		Name: actor-banshee.name
 	Buildable:
@@ -522,7 +522,7 @@ TURTLE:
 	Inherits@AutoTarget: ^AutoTargetAirAssaultMove
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 2000
+		Cost: 4000
 	Tooltip:
 		Name: actor-turtle.name
 	Buildable:
@@ -575,7 +575,7 @@ CHOPPER:
 	Inherits: ^Helicopter
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 1800
+		Cost: 3600
 	Tooltip:
 		Name: actor-chopper.name
 	Buildable:
@@ -686,7 +686,7 @@ CHOPPER.Husk:
 BALLOON:
 	Inherits: ^Helicopter
 	Valued:
-		Cost: 800
+		Cost: 1200
 	Tooltip:
 		Name: actor-balloon.name
 	Buildable:
@@ -734,7 +734,7 @@ DROPSHIP:
 	Inherits: ^Helicopter
 	Inherits@Smoke: ^SmokeEmitter
 	Valued:
-		Cost: 1800
+		Cost: 3600
 	Tooltip:
 		Name: actor-dropship.name
 	Buildable:
@@ -957,7 +957,7 @@ BOMBER:
 	Armor:
 		Type: Light
 	Valued:
-		Cost: 4000
+		Cost: 8000
 	UpdatesPlayerStatistics:
 		AddToAssetsValue: false
 	Aircraft:
@@ -991,7 +991,7 @@ CARGOSHIP:
 	Tooltip:
 		Name: actor-cargoship-name
 	Valued:
-		Cost: 4000
+		Cost: 8000
 	WithLandingUnloadAnimation:
 
 AIRLIFTER:
@@ -1011,14 +1011,14 @@ AIRLIFTER:
 	Tooltip:
 		Name: actor-airlifter-name
 	Valued:
-		Cost: 4000
+		Cost: 8000
 
 MOTHERSHIP:
 	Inherits: ^Helicopter
 	Inherits@Smoke: ^SmokeEmitter
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 15000
+		Cost: 30000
 	Tooltip:
 		Name: actor-mothership.name
 	Buildable:
@@ -1169,7 +1169,7 @@ BATTLESHIP:
 	Inherits@Smoke: ^SmokeEmitter
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 15000
+		Cost: 30000
 	Tooltip:
 		Name: actor-battleship.name
 	Buildable:

--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -1035,7 +1035,7 @@ MOTHERSHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 375000
+		HP: 187500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -1186,7 +1186,7 @@ BATTLESHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 375000
+		HP: 187500
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/hv/rules/animals.yaml
+++ b/mods/hv/rules/animals.yaml
@@ -56,7 +56,6 @@ CROW:
 	Tooltip:
 		Name: actor-crow-name
 	Aircraft:
-		CruiseAltitude: 1c0
 		Repulsable: false
 		Speed: 70
 		CruisingCondition: cruising
@@ -160,7 +159,6 @@ BIGBIRD:
 		Name: actor-bigbird.name
 		GenericName: actor-bigbird.generic-name
 	Aircraft:
-		CruiseAltitude: 1c0
 		Repulsable: false
 		Speed: 80
 		CruisingCondition: cruising

--- a/mods/hv/rules/animals.yaml
+++ b/mods/hv/rules/animals.yaml
@@ -48,7 +48,7 @@ BEAST:
 	-ProximityCaptor:
 
 CROW:
-	Inherits: ^Plane
+	Inherits: ^AirCreature
 	Valued:
 		Cost: 10
 	Health:
@@ -68,15 +68,6 @@ CROW:
 	WithShadow:
 		Offset: 200, 128, 0
 		ZOffset: -129
-	-Repairable:
-	-AppearsOnRadar:
-	-Selectable:
-	Interactable:
-	-Targetable@Airborne:
-	-ChangesHealth@Reconstructor:
-	-WithDecoration@Reconstructor:
-	-GrantConditionOnPrerequisite@Reconstructor:
-	-ProximityCaptor:
 
 CROW2:
 	Inherits: CROW
@@ -160,7 +151,7 @@ WORM:
 	DeathSounds:
 
 BIGBIRD:
-	Inherits: ^Plane
+	Inherits: ^AirCreature
 	Valued:
 		Cost: 10
 	Health:
@@ -185,16 +176,3 @@ BIGBIRD:
 		DeathPaletteIsPlayerPalette: false
 	Voiced:
 		VoiceSet: FlyingMonsterVoice
-	DeathSounds:
-	-Guard:
-	-Repairable:
-	-MustBeDestroyed:
-	-FireWarheadsOnDeath:
-	-FireWarheadsOnDeath@SpawnPilot:
-	-GrantRandomCondition@SpawnPilot:
-	-ChangesHealth@Reconstructor:
-	-WithDecoration@Reconstructor:
-	-GrantConditionOnPrerequisite@Reconstructor:
-	-Selectable:
-	Interactable:
-	-ProximityCaptor:

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -198,7 +198,7 @@ Player:
 		ExcludedUnitTypes: miner, tanker1, tanker2, broker
 	CargoBotModule:
 		RequiresCondition: enable-rogue-ai
-		TransportTypes: apc
+		TransportTypes: apc, apc2
 		PassengerTypes: mortar, flamer, shocker, rifleman, rocketeer
 	DeployActorBotModule:
 		RequiresCondition: enable-rogue-ai

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -15,11 +15,11 @@ Player:
 		MinimumBaseRadius: 15
 	BaseBuilderBotModule@RogueAI:
 		RequiresCondition: enable-rogue-ai
-		MinimumExcessPower: 40
-		MaximumExcessPower: 500
+		MinimumExcessPower: 60
+		MaximumExcessPower: 1000
 		InititalMinimumRefineryCount: 1
 		AdditionalMinimumRefineryCount: 1
-		PlaceDefenseTowardsEnemyChance: 0
+		PlaceDefenseTowardsEnemyChance: 20
 		NewProductionCashThreshold: 7000
 		WaterTerrainTypes: Littoral
 		ConstructionYardTypes: base, base2
@@ -43,8 +43,8 @@ Player:
 			orepurifier: 2
 			trader: 1
 			techcenter: 1
-			harbor: 1
-			harbor2: 1
+			harbor: 4
+			harbor2: 4
 			field: 1
 			howitzer: 1
 			uplink: 1
@@ -83,10 +83,8 @@ Player:
 			aaturret2: 150
 			turret: 150
 			turret2: 150
-			radar: 10000
-			radar2: 10000
-			factory: 11000
-			factory2: 11000
+			radar: 7500
+			radar2: 7500
 			howitzer: 12000
 			field: 12000
 			silo: 13000
@@ -97,8 +95,8 @@ Player:
 		RequiresCondition: enable-rogue-ai
 		SquadSize: 20
 		ExcludeFromSquadsTypes: miner, builder, builder2, tanker1, tanker2, minelayer, technician, broker, mineship, mineship2, blaster
-		NavalUnitsTypes: torpedoboat, railgunboat, lightboat, patrolboat, boomer, submarine, carrier
-		AirUnitsTypes: gunship, jet, copter, banshee
+		NavalUnitsTypes: mercboat, railgunboat, lightboat, patrolboat, boomer, submarine, carrier, lightningboat
+		AirUnitsTypes: gunship2, gunship3, jet, copter, turtle, banshee
 		ConstructionYardTypes: base, base2
 		ProtectionTypes: base, base2, outpost, outpost2, generator, miner2, storage, module, module2, radar, radar2, factory, factory2, harbor, harbor2, trader, starport, starport2, techcenter, bunker, bunker2, turret, aaturret, howitzer, uplink, field, silo
 	UnitBuilderBotModule@RogueAI:
@@ -115,14 +113,14 @@ Player:
 			mbt: 5
 			mbt2: 5
 			railguntank: 5
-			lightningtank: 5
+			lightningtank: 8
 			minelayer: 1
 			stealthtank: 5
 			aatank: 4
 			aatank2: 4
-			ecmtank: 1
-			hackertank: 1
-			repairtank: 1
+			ecmtank: 4
+			hackertank: 4
+			repairtank: 4
 			apc: 1
 			apc2: 1
 			artillery: 5
@@ -130,24 +128,28 @@ Player:
 			rocketeer: 1
 			mortar: 1
 			jetpacker: 1
+			jetfoiler: 1
 			sniper: 1
 			shocker: 1
 			technician: 1
+			broker: 1
 			flamer: 1
 			blaster: 1
 			missiletank: 5
-			jet: 5
-			gunship: 5
+			gunship2: 5
+			gunship3: 5
 			copter: 5
 			banshee: 5
+			turtle: 5
+			jet: 5
 			balloon: 1
 			observer: 1
-			torpedoboat: 2
+			mercboat: 2
 			submarine: 2
 			lightboat: 2
 			patrolboat: 2
 			railgunboat: 2
-			lightningboat: 2
+			lightningboat: 1
 			boomer: 2
 			carrier: 2
 			mineship: 1
@@ -155,6 +157,7 @@ Player:
 			battleship: 1
 			mothership: 1
 		UnitLimits:
+			sniper: 6
 			miner: 2
 			builder: 1
 			builder2: 1
@@ -167,15 +170,17 @@ Player:
 			mineship: 1
 			mineship2: 1
 			technician: 1
+			broker: 1
 			blaster: 3
-			apc: 1
-			apc2: 1
+			lightningboat: 6
+			jetpacker: 4
+			jetfoiler: 4
 		UnitDelays:
 			builder: 7500
 			builder2: 7500
 	PriorityCaptureManagerBotModule:
 		RequiresCondition: enable-rogue-ai
-		CapturingActorTypes: technician
+		CapturingActorTypes: technician, broker
 		PriorityCapturableActorTypes: reconstructor, extractor, comlink, dropzone
 		MinimumCaptureDelay: 0
 		MaximumCaptureTargetOptions: 25
@@ -202,7 +207,7 @@ Player:
 		PassengerTypes: mortar, flamer, shocker, rifleman, rocketeer
 	DeployActorBotModule:
 		RequiresCondition: enable-rogue-ai
-		DeployableActorTypes: radartank
+		DeployableActorTypes: radartank, hackertank, railgunboat
 	PowerDownBotModule:
 		RequiresCondition: enable-rogue-ai
 	ScoutBotModule:

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -20,7 +20,7 @@ Player:
 		InititalMinimumRefineryCount: 1
 		AdditionalMinimumRefineryCount: 1
 		PlaceDefenseTowardsEnemyChance: 20
-		NewProductionCashThreshold: 7000
+		NewProductionCashThreshold: 7500
 		WaterTerrainTypes: Littoral
 		ConstructionYardTypes: base, base2
 		PowerTypes: generator
@@ -77,12 +77,10 @@ Player:
 			field: 1
 			silo: 1
 		BuildingDelays:
-			bunker: 150
-			bunker2: 150
-			aaturret: 150
-			aaturret2: 150
-			turret: 150
-			turret2: 150
+			module: 100
+			module2: 100
+			factory: 2000
+			factory2: 2000
 			radar: 7500
 			radar2: 7500
 			howitzer: 12000
@@ -110,8 +108,8 @@ Player:
 			radartank: 1
 			buggy: 3
 			bike: 3
-			mbt: 5
-			mbt2: 5
+			mbt: 2
+			mbt2: 2
 			railguntank: 5
 			lightningtank: 8
 			minelayer: 1
@@ -175,7 +173,13 @@ Player:
 			lightningboat: 6
 			jetpacker: 4
 			jetfoiler: 4
+			mbt: 6
+			mbt2: 6
 		UnitDelays:
+			mortar: 1500
+			sniper: 1500
+			rocketeer: 3000
+			shocker: 3000
 			builder: 7500
 			builder2: 7500
 	PriorityCaptureManagerBotModule:

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -181,7 +181,7 @@ Player:
 	PriorityCaptureManagerBotModule:
 		RequiresCondition: enable-rogue-ai
 		CapturingActorTypes: technician, broker
-		PriorityCapturableActorTypes: reconstructor, extractor, comlink, dropzone
+		PriorityCapturableActorTypes: reconstructor, extractor, comlink, dropzone, miner2
 		MinimumCaptureDelay: 0
 		MaximumCaptureTargetOptions: 25
 		CheckCaptureTargetsForVisibility: False

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -20,7 +20,7 @@ Player:
 		InititalMinimumRefineryCount: 1
 		AdditionalMinimumRefineryCount: 1
 		PlaceDefenseTowardsEnemyChance: 20
-		NewProductionCashThreshold: 7500
+		NewProductionCashThreshold: 7000
 		WaterTerrainTypes: Littoral
 		ConstructionYardTypes: base, base2
 		PowerTypes: generator
@@ -64,8 +64,8 @@ Player:
 			starport: 1
 			starport2: 1
 			techcenter: 1
-			oresmelt: 20
-			orepurifier: 20
+			oresmelt: 10
+			orepurifier: 10
 			bunker: 12
 			bunker2: 12
 			turret: 12
@@ -77,10 +77,10 @@ Player:
 			field: 1
 			silo: 1
 		BuildingDelays:
-			module: 100
-			module2: 100
-			factory: 2000
-			factory2: 2000
+			factory: 2250
+			factory2: 2250
+			harbor: 2250
+			harbor2: 2250
 			radar: 7500
 			radar2: 7500
 			howitzer: 12000
@@ -155,7 +155,7 @@ Player:
 			battleship: 1
 			mothership: 1
 		UnitLimits:
-			sniper: 6
+			sniper: 4
 			miner: 2
 			builder: 1
 			builder2: 1
@@ -176,12 +176,17 @@ Player:
 			mbt: 6
 			mbt2: 6
 		UnitDelays:
-			mortar: 1500
-			sniper: 1500
+			mortar: 1000
+			sniper: 1000
 			rocketeer: 3000
 			shocker: 3000
+			aatank: 5000
+			aatank2: 5000
 			builder: 7500
 			builder2: 7500
+			repairtank: 8500
+			blaster: 12500
+			radartank: 20000
 	PriorityCaptureManagerBotModule:
 		RequiresCondition: enable-rogue-ai
 		CapturingActorTypes: technician, broker

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -15,11 +15,11 @@ Player:
 		MinimumBaseRadius: 15
 	BaseBuilderBotModule@RogueAI:
 		RequiresCondition: enable-rogue-ai
-		MinimumExcessPower: 40
-		MaximumExcessPower: 500
+		MinimumExcessPower: 60
+		MaximumExcessPower: 1000
 		InititalMinimumRefineryCount: 1
 		AdditionalMinimumRefineryCount: 1
-		PlaceDefenseTowardsEnemyChance: 0
+		PlaceDefenseTowardsEnemyChance: 20
 		NewProductionCashThreshold: 7000
 		WaterTerrainTypes: Littoral
 		ConstructionYardTypes: base, base2
@@ -43,8 +43,8 @@ Player:
 			orepurifier: 2
 			trader: 1
 			techcenter: 1
-			harbor: 1
-			harbor2: 1
+			harbor: 4
+			harbor2: 4
 			field: 1
 			howitzer: 1
 			uplink: 1
@@ -64,8 +64,8 @@ Player:
 			starport: 1
 			starport2: 1
 			techcenter: 1
-			oresmelt: 20
-			orepurifier: 20
+			oresmelt: 10
+			orepurifier: 10
 			bunker: 12
 			bunker2: 12
 			turret: 12
@@ -77,16 +77,12 @@ Player:
 			field: 1
 			silo: 1
 		BuildingDelays:
-			bunker: 150
-			bunker2: 150
-			aaturret: 150
-			aaturret2: 150
-			turret: 150
-			turret2: 150
-			radar: 10000
-			radar2: 10000
-			factory: 11000
-			factory2: 11000
+			factory: 2250
+			factory2: 2250
+			harbor: 2250
+			harbor2: 2250
+			radar: 7500
+			radar2: 7500
 			howitzer: 12000
 			field: 12000
 			silo: 13000
@@ -95,10 +91,10 @@ Player:
 		RequiresCondition: enable-rogue-ai
 	SquadManagerBotModule@RogueAI:
 		RequiresCondition: enable-rogue-ai
-		SquadSize: 20
-		ExcludeFromSquadsTypes: miner, builder, builder2, tanker1, tanker2, minelayer, technician, broker, mineship, mineship2, blaster
-		NavalUnitsTypes: torpedoboat, railgunboat, lightboat, patrolboat, boomer, submarine, carrier
-		AirUnitsTypes: gunship, jet, copter, banshee
+		SquadSize: 16
+		ExcludeFromSquadsTypes: miner, builder, builder2, tanker1, tanker2, minelayer, technician, broker, mineship, mineship2, blaster, rifleman
+		NavalUnitsTypes: mercboat, railgunboat, lightboat, patrolboat, boomer, submarine, carrier, lightningboat
+		AirUnitsTypes: gunship2, gunship3, jet, copter, turtle, banshee
 		ConstructionYardTypes: base, base2
 		ProtectionTypes: base, base2, outpost, outpost2, generator, miner2, storage, module, module2, radar, radar2, factory, factory2, harbor, harbor2, trader, starport, starport2, techcenter, bunker, bunker2, turret, aaturret, howitzer, uplink, field, silo
 	UnitBuilderBotModule@RogueAI:
@@ -112,17 +108,17 @@ Player:
 			radartank: 1
 			buggy: 3
 			bike: 3
-			mbt: 5
-			mbt2: 5
+			mbt: 2
+			mbt2: 2
 			railguntank: 5
-			lightningtank: 5
+			lightningtank: 8
 			minelayer: 1
 			stealthtank: 5
 			aatank: 4
 			aatank2: 4
-			ecmtank: 1
-			hackertank: 1
-			repairtank: 1
+			ecmtank: 4
+			hackertank: 4
+			repairtank: 4
 			apc: 1
 			apc2: 1
 			artillery: 5
@@ -130,24 +126,28 @@ Player:
 			rocketeer: 1
 			mortar: 1
 			jetpacker: 1
+			jetfoiler: 1
 			sniper: 1
 			shocker: 1
 			technician: 1
+			broker: 1
 			flamer: 1
 			blaster: 1
 			missiletank: 5
-			jet: 5
-			gunship: 5
+			gunship2: 5
+			gunship3: 5
 			copter: 5
 			banshee: 5
+			turtle: 5
+			jet: 5
 			balloon: 1
 			observer: 1
-			torpedoboat: 2
+			mercboat: 2
 			submarine: 2
 			lightboat: 2
 			patrolboat: 2
 			railgunboat: 2
-			lightningboat: 2
+			lightningboat: 1
 			boomer: 2
 			carrier: 2
 			mineship: 1
@@ -155,6 +155,9 @@ Player:
 			battleship: 1
 			mothership: 1
 		UnitLimits:
+			sniper: 4
+			buggy: 2
+			bike: 2
 			miner: 2
 			builder: 1
 			builder2: 1
@@ -167,16 +170,30 @@ Player:
 			mineship: 1
 			mineship2: 1
 			technician: 1
+			broker: 1
 			blaster: 3
-			apc: 1
-			apc2: 1
+			lightningboat: 6
+			jetpacker: 2
+			jetfoiler: 2
+			mbt: 6
+			mbt2: 6
 		UnitDelays:
+			mortar: 1000
+			sniper: 1000
+			rocketeer: 3000
+			shocker: 3000
+			aatank: 5000
+			aatank2: 5000
 			builder: 7500
 			builder2: 7500
+			repairtank: 8500
+			blaster: 12500
+			radartank: 20000
 	PriorityCaptureManagerBotModule:
 		RequiresCondition: enable-rogue-ai
-		CapturingActorTypes: technician
-		PriorityCapturableActorTypes: reconstructor, extractor, comlink, dropzone
+		CapturingActorTypes: technician, broker
+		PriorityCapturableActorTypes: reconstructor, extractor, miner2, techcenter, factory, factory2, module, module2, starport, starport2, radar, radar2, field, howitzer, silo, uplink, base
+		CapturableActorTypes: base, base2, outpost, outpost2, generator, radar, radar2, trader, module, module2, miner2, starport, starport2, factory, factory2, techcenter, oresmelt, orepurifier, howitzer, field, silo, uplink, storage, reconstructor, extractor
 		MinimumCaptureDelay: 0
 		MaximumCaptureTargetOptions: 25
 		CheckCaptureTargetsForVisibility: False
@@ -202,7 +219,7 @@ Player:
 		PassengerTypes: mortar, flamer, shocker, rifleman, rocketeer
 	DeployActorBotModule:
 		RequiresCondition: enable-rogue-ai
-		DeployableActorTypes: radartank
+		DeployableActorTypes: radartank, hackertank, railgunboat
 	PowerDownBotModule:
 		RequiresCondition: enable-rogue-ai
 	ScoutBotModule:
@@ -229,21 +246,21 @@ Player:
 					Types: Structure
 					Attractiveness: 1
 					TargetMetric: Value
-					CheckRadius: 5c0
+					CheckRadius: 1c0
 				Consideration@2:
 					Against: Ally
 					Types: Air, Ground, Water
 					Attractiveness: -10
 					TargetMetric: Value
-					CheckRadius: 7c0
+					CheckRadius: 6c0
 			DropPods:
 				OrderName: EjectPods
 				MinimumAttractiveness: 5
 				Consideration@1:
 					Against: Enemy
-					Types: Structure
+					Types: Structure, Air, Tank, Vehicle, Infantry
 					Attractiveness: 1
-					TargetMetric: None
+					TargetMetric: Value
 					CheckRadius: 8c0
 				Consideration@2:
 					Against: Enemy
@@ -259,7 +276,7 @@ Player:
 					Types: Structure
 					Attractiveness: 1
 					TargetMetric: None
-					CheckRadius: 5c0
+					CheckRadius: 1c0
 			Howitzer:
 				OrderName: FireMission
 				MinimumAttractiveness: 1
@@ -268,7 +285,7 @@ Player:
 					Types: Structure
 					Attractiveness: 1
 					TargetMetric: None
-					CheckRadius: 5c0
+					CheckRadius: 1c0
 			Railgun:
 				OrderName: Blastem
 				MinimumAttractiveness: 1000
@@ -284,10 +301,10 @@ Player:
 					Types: Structure
 					Attractiveness: 1
 					TargetMetric: Value
-					CheckRadius: 2c0
+					CheckRadius: 1c0
 				Consideration@3:
 					Against: Ally
 					Types: Ground, Water
 					Attractiveness: -10
 					TargetMetric: Value
-					CheckRadius: 3c0
+					CheckRadius: 2c0

--- a/mods/hv/rules/bots.yaml
+++ b/mods/hv/rules/bots.yaml
@@ -15,7 +15,7 @@ Player:
 		MinimumBaseRadius: 15
 	BaseBuilderBotModule@RogueAI:
 		RequiresCondition: enable-rogue-ai
-		MinimumExcessPower: 60
+		MinimumExcessPower: 50
 		MaximumExcessPower: 1000
 		InititalMinimumRefineryCount: 1
 		AdditionalMinimumRefineryCount: 1
@@ -25,12 +25,14 @@ Player:
 		ConstructionYardTypes: base, base2
 		PowerTypes: generator
 		ProductionTypes: module, module2, factory, factory2, starport, starport2, harbor, harbor2, base, base2
+		BarracksTypes: module, module2
+		VehiclesFactoryTypes: factory, factory2
 		NavalProductionTypes: harbor, harbor2
 		RefineryTypes: storage
 		DefenseTypes: turret, turret2, aaturret, aaturret2, bunker, bunker2
 		BuildingLimits:
 			base: 1
-			storage: 3
+			storage: 4
 			module: 4
 			module2: 4
 			factory: 4
@@ -77,12 +79,9 @@ Player:
 			field: 1
 			silo: 1
 		BuildingDelays:
-			factory: 2250
-			factory2: 2250
-			harbor: 2250
-			harbor2: 2250
-			radar: 7500
-			radar2: 7500
+			storage: 50
+			radar: 1500
+			radar2: 1500
 			howitzer: 12000
 			field: 12000
 			silo: 13000
@@ -91,6 +90,9 @@ Player:
 		RequiresCondition: enable-rogue-ai
 	SquadManagerBotModule@RogueAI:
 		RequiresCondition: enable-rogue-ai
+		IdleScanRadius: 20
+		DangerScanRadius: 20
+		AttackScanRadius: 20
 		SquadSize: 16
 		ExcludeFromSquadsTypes: miner, builder, builder2, tanker1, tanker2, minelayer, technician, broker, mineship, mineship2, blaster, rifleman
 		NavalUnitsTypes: mercboat, railgunboat, lightboat, patrolboat, boomer, submarine, carrier, lightningboat
@@ -155,7 +157,7 @@ Player:
 			battleship: 1
 			mothership: 1
 		UnitLimits:
-			sniper: 4
+			sniper: 3
 			buggy: 2
 			bike: 2
 			miner: 2
@@ -172,20 +174,20 @@ Player:
 			technician: 1
 			broker: 1
 			blaster: 3
-			lightningboat: 6
+			lightningboat: 4
 			jetpacker: 2
 			jetfoiler: 2
 			mbt: 6
 			mbt2: 6
 		UnitDelays:
-			mortar: 1000
-			sniper: 1000
 			rocketeer: 3000
 			shocker: 3000
 			aatank: 5000
 			aatank2: 5000
 			builder: 7500
 			builder2: 7500
+			turtle: 7500
+			jet: 7500
 			repairtank: 8500
 			blaster: 12500
 			radartank: 20000
@@ -258,7 +260,7 @@ Player:
 				MinimumAttractiveness: 5
 				Consideration@1:
 					Against: Enemy
-					Types: Structure, Air, Tank, Vehicle, Infantry
+					Types: Structure, Tank, Vehicle, Infantry
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 8c0

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -1070,7 +1070,7 @@ TECHCENTER:
 		Prerequisites: ~base, radar
 		Description: actor-techcenter.description
 	Valued:
-		Cost: 2000
+		Cost: 3000
 	Tooltip:
 		Name: actor-techcenter.name
 	Encyclopedia:
@@ -1096,7 +1096,7 @@ TECHCENTER:
 	RevealsShroud@Hacked:
 		Range: 2c0
 	Power:
-		Amount: -200
+		Amount: -250
 	Targetable:
 		TargetTypes: Ground, Structure
 	RenderSprites:
@@ -1545,7 +1545,7 @@ SILO:
 	Selectable:
 		Bounds: 2048, 3072, 0, -1024
 	Valued:
-		Cost: 2500
+		Cost: 3000
 	Tooltip:
 		Name: actor-silo.name
 	Encyclopedia:
@@ -1604,7 +1604,7 @@ SILO:
 		CircleWidth: 2
 	SupportPowerChargeBar:
 	Power:
-		Amount: -150
+		Amount: -250
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	WithIdleOverlay@Lights:
@@ -1657,7 +1657,7 @@ UPLINK:
 		Range: 4c0
 	SupportPowerChargeBar:
 	Power:
-		Amount: -150
+		Amount: -200
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	WithIdleOverlay@Lights:

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -1324,9 +1324,9 @@ AATURRET:
 		Type: Turret
 		Width: 2
 		BorderWidth: 3
-		Range: 9c0
-	RevealsShroud:
 		Range: 10c0
+	RevealsShroud:
+		Range: 11c0
 	WithSpriteTurret:
 		RequiresCondition: !build-incomplete
 	WithTurretAttackAnimation:
@@ -1374,9 +1374,9 @@ AATURRET2:
 		Type: Turret
 		Width: 2
 		BorderWidth: 3
-		Range: 9c0
-	RevealsShroud:
 		Range: 10c0
+	RevealsShroud:
+		Range: 11c0
 	WithSpriteTurret:
 		RequiresCondition: !build-incomplete
 	WithTurretAttackAnimation:

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -20,7 +20,7 @@ BASE:
 			TopLeft: -1024, -2048
 			BottomRight: 1024, 1024
 	Health:
-		HP: 250000
+		HP: 375000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -262,7 +262,7 @@ OUTPOST:
 		Scale: 2
 		Category: Buildings
 	Health:
-		HP: 50000
+		HP: 75000
 	Building:
 		Footprint: + x
 		Dimensions: 1,2
@@ -318,7 +318,7 @@ GENERATOR:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 40000
+		HP: 60000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -365,7 +365,7 @@ RADAR:
 	Targetable:
 		TargetTypes: Ground, Structure
 	Health:
-		HP: 100000
+		HP: 150000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -468,7 +468,7 @@ TRADER:
 	Selectable:
 		Bounds: 2048, 2048
 	Health:
-		HP: 80000
+		HP: 120000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -565,7 +565,7 @@ MODULE:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 60000
+		HP: 90000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -670,7 +670,7 @@ MINER2:
 	Valued:
 		Cost: 1000
 	Health:
-		HP: 45000
+		HP: 67500
 	ProvidesPrerequisite@BuildingName:
 	ResourceCollector:
 		InitialDelay: 100
@@ -742,7 +742,7 @@ STARPORT:
 		Footprint: xx xx xx
 		Dimensions: 2,3
 	Health:
-		HP: 80000
+		HP: 120000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -832,7 +832,7 @@ FACTORY:
 	HitShape:
 		TargetableOffsets: 0,0,0, -512,-512,0, -512,512,0, -1536,-512,0, -1536,512,0
 	Health:
-		HP: 80000
+		HP: 120000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -1086,7 +1086,7 @@ TECHCENTER:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,512,0
 	Health:
-		HP: 100000
+		HP: 150000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -1133,7 +1133,7 @@ ORESMELT:
 			TopLeft: -512, -512
 			BottomRight: 512, 1024
 	Health:
-		HP: 40000
+		HP: 60000
 	Power:
 		Amount: -80
 	Building:
@@ -1184,7 +1184,7 @@ BUNKER:
 		Scale: 2
 		Category: Buildings
 	Health:
-		HP: 40000
+		HP: 60000
 	Turreted:
 		TurnSpeed: 512
 	Building:
@@ -1240,7 +1240,7 @@ TURRET:
 		Scale: 2
 		Category: Buildings
 	Health:
-		HP: 55000
+		HP: 82500
 	Armament:
 		Weapon: TurretCannon
 		LocalOffset: 1200,50,0
@@ -1275,7 +1275,7 @@ TURRET2:
 	Tooltip:
 		Name: actor-turret2.name
 	Health:
-		HP: 55000
+		HP: 82500
 	Armament:
 		Weapon: Turret2Cannon
 		LocalOffset: 800,0,300
@@ -1314,7 +1314,7 @@ AATURRET:
 	Tooltip:
 		Name: actor-aaturret.name
 	Health:
-		HP: 55000
+		HP: 82500
 	Armor:
 		Type: Steel
 	Armament:
@@ -1366,7 +1366,7 @@ AATURRET2:
 		Scale: 2
 		Category: Buildings
 	Health:
-		HP: 55000
+		HP: 82500
 	Armament:
 		Weapon: TowerMissile
 		LocalOffset: 256,375,760, 256,-375,760
@@ -1414,7 +1414,7 @@ HOWITZER:
 		UseTargetableCellsOffsets: False
 		TargetableOffsets: -256,-256,0,   256,-256,0,   -256,256,0,   256,256,0
 	Health:
-		HP: 100000
+		HP: 150000
 	RevealsShroud:
 		Range: 8c0
 		MinRange: 4c0
@@ -1487,7 +1487,7 @@ FIELD:
 	Selectable:
 		Bounds: 2048, 2048
 	Health:
-		HP: 100000
+		HP: 150000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -1564,7 +1564,7 @@ SILO:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,1024,0
 	Health:
-		HP: 100000
+		HP: 150000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -1646,7 +1646,7 @@ UPLINK:
 			TopLeft: -1048, 512
 			BottomRight: 1048, 1524
 	Health:
-		HP: 100000
+		HP: 150000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -1717,7 +1717,7 @@ STORAGE:
 		Scale: 2
 		Category: Buildings
 	Health:
-		HP: 100000
+		HP: 150000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -1802,7 +1802,7 @@ TELEVATOR:
 		Footprint: ++
 		Dimensions: 2,1
 	Health:
-		HP: 100000
+		HP: 150000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -1908,7 +1908,7 @@ HARBOR:
 	Targetable:
 		TargetTypes: Ground, Structure, WaterBuilding
 	Health:
-		HP: 80000
+		HP: 120000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -2034,7 +2034,7 @@ BARRIER:
 	Targetable:
 		TargetTypes: Ground, Wall, NoAutoTarget
 	Health:
-		HP: 100000
+		HP: 150000
 	Armor:
 		Type: Concrete
 	BlocksProjectiles:
@@ -2505,7 +2505,7 @@ RECONSTRUCTOR:
 	Targetable:
 		TargetTypes: Ground, Structure
 	Health:
-		HP: 100000
+		HP: 150000
 	Armor:
 		Type: Steel
 	RevealsShroud:
@@ -2767,7 +2767,7 @@ DROPZONE:
 		Amount: -40
 		RequiresCondition: !ownerless
 	Health:
-		HP: 80000
+		HP: 120000
 	WithIdleAnimation:
 		Interval: 80
 		RequiresCondition: !disabled && !ownerless && !burning
@@ -2821,7 +2821,7 @@ FLAGPOST:
 		Scale: 2
 		Category: Buildings
 	Health:
-		HP: 50000
+		HP: 75000
 	Building:
 		Footprint: = x
 		Dimensions: 1,2

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -714,6 +714,8 @@ MINER2:
 		RequiresCondition: !build-incomplete && !critical
 	CaptureManager:
 		-BeingCapturedCondition: being-captured
+	Targetable:
+		TargetTypes: Ground, Structure, Defraudable
 
 STARPORT:
 	Inherits: ^BaseBuilding
@@ -1145,6 +1147,8 @@ ORESMELT:
 	WithIdleAnimation:
 		Interval: 40
 		RequiresCondition: !build-incomplete && !disabled && !burning && !selling
+	Targetable:
+		TargetTypes: Ground, Structure, Defraudable
 
 OREPURIFIER:
 	Inherits: ORESMELT

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -842,7 +842,7 @@ FACTORY:
 	RevealsShroud@Hacked:
 		Range: 2c0
 	Power:
-		Amount: -150
+		Amount: -120
 	ProvidesPrerequisite@BuildingName:
 		RequiresCondition: !powerdown
 	ProvidesPrerequisite@Generic:
@@ -1096,7 +1096,7 @@ TECHCENTER:
 	RevealsShroud@Hacked:
 		Range: 2c0
 	Power:
-		Amount: -250
+		Amount: -240
 	Targetable:
 		TargetTypes: Ground, Structure
 	RenderSprites:
@@ -1604,7 +1604,7 @@ SILO:
 		CircleWidth: 2
 	SupportPowerChargeBar:
 	Power:
-		Amount: -250
+		Amount: -240
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	WithIdleOverlay@Lights:

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -714,6 +714,8 @@ MINER2:
 		RequiresCondition: !build-incomplete && !critical
 	CaptureManager:
 		-BeingCapturedCondition: being-captured
+	Targetable:
+		TargetTypes: Ground, Structure
 
 STARPORT:
 	Inherits: ^BaseBuilding
@@ -1145,6 +1147,8 @@ ORESMELT:
 	WithIdleAnimation:
 		Interval: 40
 		RequiresCondition: !build-incomplete && !disabled && !burning && !selling
+	Targetable:
+		TargetTypes: Ground, Structure
 
 OREPURIFIER:
 	Inherits: ORESMELT

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -842,7 +842,7 @@ FACTORY:
 	RevealsShroud@Hacked:
 		Range: 2c0
 	Power:
-		Amount: -150
+		Amount: -120
 	ProvidesPrerequisite@BuildingName:
 		RequiresCondition: !powerdown
 	ProvidesPrerequisite@Generic:
@@ -1070,7 +1070,7 @@ TECHCENTER:
 		Prerequisites: ~base, radar
 		Description: actor-techcenter.description
 	Valued:
-		Cost: 2000
+		Cost: 3000
 	Tooltip:
 		Name: actor-techcenter.name
 	Encyclopedia:
@@ -1096,7 +1096,7 @@ TECHCENTER:
 	RevealsShroud@Hacked:
 		Range: 2c0
 	Power:
-		Amount: -200
+		Amount: -240
 	Targetable:
 		TargetTypes: Ground, Structure
 	RenderSprites:
@@ -1545,7 +1545,7 @@ SILO:
 	Selectable:
 		Bounds: 2048, 3072, 0, -1024
 	Valued:
-		Cost: 2500
+		Cost: 3000
 	Tooltip:
 		Name: actor-silo.name
 	Encyclopedia:
@@ -1604,7 +1604,7 @@ SILO:
 		CircleWidth: 2
 	SupportPowerChargeBar:
 	Power:
-		Amount: -150
+		Amount: -240
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	WithIdleOverlay@Lights:
@@ -1657,7 +1657,7 @@ UPLINK:
 		Range: 4c0
 	SupportPowerChargeBar:
 	Power:
-		Amount: -150
+		Amount: -240
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	WithIdleOverlay@Lights:

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -176,7 +176,7 @@
 		TextNotification: notification-enemy-units-detected
 	Passenger:
 		CargoType: Vehicle
-		Weight: 5
+		Weight: 4
 
 ^Pod:
 	Inherits: ^Vehicle

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -188,7 +188,7 @@
 	Voiced:
 		VoiceSet: GenericVoice2
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: None
 	Passenger:
@@ -204,7 +204,7 @@
 	Crushable:
 		RequiresCondition: !shield
 		CrushClasses: Pods
-		WarnProbability: 15
+		WarnProbability: 50
 	RevealsShroud:
 		Range: 4c0
 		MinRange: 2c0
@@ -330,6 +330,22 @@
 		Weapon: UnitExplodeMedium
 		EmptyWeapon: UnitExplodeMedium
 
+^AirCreature:
+	Inherits: ^Plane
+	DeathSounds:
+	-AppearsOnRadar:
+	-Guard:
+	-Repairable:
+	-MustBeDestroyed:
+	-GrantRandomCondition@SpawnPilot:
+	-FireWarheadsOnDeath@SpawnPilot:
+	-ChangesHealth@Reconstructor:
+	-WithDecoration@Reconstructor:
+	-GrantConditionOnPrerequisite@Reconstructor:
+	-Selectable:
+	Interactable:
+	-ProximityCaptor:
+
 ^PlaneHusk:
 	Inherits@Husk: ^Husk
 	Inherits@Sprite: ^SpriteActor
@@ -363,6 +379,30 @@
 	FireWarheadsOnDeath:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
+
+^BaseDrone:
+	Inherits: ^SpawnedPlane
+	Valued:
+		Cost: 100
+	Armor:
+		Type: Light
+	RevealsShroud:
+		Range: 4c0
+		MinRange: 2c0
+		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 2c0
+		Type: GroundPosition
+	Aircraft:
+		TurnSpeed: 60
+		AltitudeVelocity: 240
+		VTOL: true
+		Repulsable: false
+		AirborneCondition: airborne
+		CanHover: False
+		LandAltitude: 0c0
+	-MapEditorData:
 
 ^CargoPlane:
 	Inherits@Exists: ^ExistsInWorld
@@ -456,6 +496,19 @@
 		FallTicks: 8
 		RiseTicks: 8
 	BodyOrientation:
+
+^Hovercraft:
+	Inherits: ^Plane
+	Aircraft:
+		CanHover: True
+		CruisingCondition: cruising
+		WaitDistanceFromResupplyBase: 4c0
+	Hovers@Cruising:
+		RequiresCondition: cruising
+		BobDistance: -64
+		InitialHeight: 64
+		FallTicks: 8
+		RiseTicks: 8
 
 ^1x1Shape:
 	HitShape:
@@ -1345,3 +1398,10 @@
 		Bounds: 512, 512
 	Voiced:
 		VoiceSet: CivilianVoice
+
+^WeaponReloadDelayUpgrade:
+	ReloadDelayMultiplier:
+		Modifier: 75
+		RequiresCondition: lightningboat-reloaddelay-increase
+	ExternalCondition:
+		Condition: lightningboat-reloaddelay-increase

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -282,7 +282,7 @@
 		Bounds: 1024, 1024
 	Aircraft:
 		AirborneCondition: airborne
-		CruiseAltitude: 2c0
+		CruiseAltitude: 2600
 		InitialFacing: 768
 		Voice: Move
 		TakeOffOnResupply: true
@@ -332,6 +332,8 @@
 
 ^AirCreature:
 	Inherits: ^Plane
+	Aircraft:
+		CruiseAltitude: 2560
 	DeathSounds:
 	-AppearsOnRadar:
 	-Guard:

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -580,7 +580,7 @@
 	Armor:
 		Type: Steel
 	Health:
-		HP: 40000
+		HP: 60000
 	Building:
 		Footprint: x
 	ActorPreviewPlaceBuildingPreview:
@@ -1297,7 +1297,7 @@
 	Valued:
 		Cost: 300
 	Health:
-		HP: 75000
+		HP: 112500
 	Armor:
 		Type: Concrete
 	LineBuildNode:

--- a/mods/hv/rules/infantry.yaml
+++ b/mods/hv/rules/infantry.yaml
@@ -6,7 +6,7 @@ RIFLEMAN:
 	Buildable:
 		Queue: Pod
 		Description: actor-rifleman.description
-		Prerequisites: ~module
+		Prerequisites: ~disabled
 		BuildPaletteOrder: 10
 	Encyclopedia:
 		Description: actor-rifleman.encyclopedia
@@ -67,12 +67,20 @@ ROCKETEER:
 	RevealsShroud@Hacked:
 		Range: 3c0
 	Armament@Primary:
-		Weapon: LightPodRocket
+		Weapon: LightPodRocketGround
 		MuzzleSequence: muzzle
 		LocalOffset: 50,0,0
-	Armament@Garrisoned:
+	Armament@Secondary:
+		Weapon: LightPodRocketAir
+		MuzzleSequence: muzzle
+		LocalOffset: 50,0,0
+	Armament@Garrisoned@Primary:
 		Name: garrisoned
-		Weapon: RapidPodRocket
+		Weapon: RapidPodRocketGround
+		MuzzleSequence: muzzle
+	Armament@Garrisoned@Secondary:
+		Name: garrisoned
+		Weapon: RapidPodRocketAir
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		PauseOnCondition: jammed
@@ -86,8 +94,8 @@ MORTAR:
 	Buildable:
 		Queue: Pod
 		Description: actor-mortar.description
-		Prerequisites: ~module.sc, factory
-		BuildPaletteOrder: 50
+		Prerequisites: ~module.sc
+		BuildPaletteOrder: 10
 	Encyclopedia:
 		Description: actor-mortar.encyclopedia
 		Order: 35
@@ -127,24 +135,23 @@ SNIPER:
 	Buildable:
 		Queue: Pod
 		Description: actor-sniper.description
-		Prerequisites: ~module.yi, radar
-		BuildPaletteOrder: 50
+		Prerequisites: ~module.yi
+		BuildPaletteOrder: 10
 	Encyclopedia:
 		Description: actor-sniper.encyclopedia
 		Order: 30
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1000
+		Cost: 600
 	Tooltip:
 		Name: actor-sniper.name
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
-	Health:
-		HP: 15000
 	Mobile:
 		Speed: 70
-		Locomotor: pod
+	Health:
+		HP: 15750
 	RevealsShroud:
 		Range: 10c0
 		MinRange: 5c0
@@ -166,12 +173,16 @@ SNIPER:
 	Cloak:
 		InitialDelay: 250
 		CloakDelay: 120
-		CloakSound:
-		UncloakSound:
+		CloakSound: stealth_on_humanoide9000.ogg
+		UncloakSound: stealth_off_humanoide9000.ogg
 		UncloakOn: Attack, Unload, Move
+		PauseOnCondition: cloak-force-disabled || jammed
 		IsPlayerPalette: true
 		CloakedPalette: cloak
 		CloakStyle: Palette
+	GrantConditionOnDamageState@UNCLOAK:
+		Condition: cloak-force-disabled
+		ValidDamageStates: Critical
 
 FLAMER:
 	Inherits: ^Pod
@@ -179,7 +190,7 @@ FLAMER:
 	Buildable:
 		Queue: Pod
 		Description: actor-flamer.description
-		Prerequisites: ~module.sc, factory
+		Prerequisites: ~module.sc, radar
 		BuildPaletteOrder: 40
 	Encyclopedia:
 		Description: actor-flamer.encyclopedia
@@ -187,15 +198,13 @@ FLAMER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 700
+		Cost: 750
 	Tooltip:
 		Name: actor-flamer.name
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
-	Mobile:
-		Speed: 70
+		HP: 30000
 	RevealsShroud:
 		Range: 5c0
 		MinRange: 2c0
@@ -221,7 +230,7 @@ TECHNICIAN:
 	Buildable:
 		Queue: Pod
 		Description: actor-technician.description
-		Prerequisites: ~module
+		Prerequisites: ~module.sc
 		BuildPaletteOrder: 30
 	Encyclopedia:
 		Description: actor-technician.encyclopedia
@@ -254,7 +263,7 @@ TECHNICIAN:
 	Guard:
 		Voice: Action
 	Health:
-		HP: 12500
+		HP: 18750
 	Mobile:
 		Speed: 70
 	AutoTarget:
@@ -281,15 +290,15 @@ BROKER:
 	Buildable:
 		Queue: Pod
 		Description: actor-broker.description
-		Prerequisites: trader
-		BuildPaletteOrder: 70
+		Prerequisites: ~module.yi
+		BuildPaletteOrder: 30
 	Encyclopedia:
 		Description: actor-broker.encyclopedia
-		Order: 16
+		Order: 15
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1400
+		Cost: 1000
 	Tooltip:
 		Name: actor-broker.name
 	UpdatesPlayerStatistics:
@@ -300,11 +309,23 @@ BROKER:
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 2c0
+	CaptureManager:
+	Captures:
+		CaptureTypes: building
+		PlayerExperience: 25
+		CaptureDelay: 375
+		ConsumedByCapture: false
+		EnterCursor: ability
+		EnterBlockedCursor: move-blocked
+		RequiresCondition: !deployed && !jammed
 	Health:
-		HP: 17500
+		HP: 18750
+	Mobile:
+		Speed: 70
 	Voiced:
 		VoiceSet: BrokerVoice
 	GrantConditionOnAttack:
+		RequiresCondition: deployed
 		Condition: chargeup-wiretransfer
 		RevokeDelay: 220
 		MaximumInstances: 11
@@ -313,14 +334,16 @@ BROKER:
 		IsCyclic: true
 	Armament@PrepareStage1:
 		Weapon: BrokerPrepareWireTransferStage1
-		RequiresCondition: chargeup-wiretransfer < 6
+		RequiresCondition: deployed && chargeup-wiretransfer < 6
 	Armament@PrepareStage2:
 		Weapon: BrokerPrepareWireTransferStage2
-		RequiresCondition: chargeup-wiretransfer > 5 && chargeup-wiretransfer < 11
+		RequiresCondition: deployed && chargeup-wiretransfer > 5 && chargeup-wiretransfer < 11
 	Armament@Steal:
 		Weapon: BrokerWireTransfer
-		RequiresCondition: chargeup-wiretransfer == 11
+		RequiresCondition: deployed && chargeup-wiretransfer == 11
 	AttackFrontal:
+		RequiresCondition: deployed
+		PauseOnCondition: jammed
 		FacingTolerance: 10
 		Voice: Attack
 	AutoTarget:
@@ -329,14 +352,41 @@ BROKER:
 	AutoTargetPriority@Default:
 		ValidTargets: Defraudable
 		InvalidTargets: NoAutoTarget
+	GrantConditionOnDeploy:
+		PauseOnCondition: jammed
+		DeployedCondition: deployed
+		UndeployedCondition: undeployed
+		UndeployOnMove: true
+		UndeployOnPickup: true
+		Facing: 512
+		DeploySounds: broker_deploy_mincedbeats.ogg
+		UndeploySounds: broker_undeploy_mincedbeats.ogg
+		AllowedTerrainTypes: Clear, Road, Crater, Grass, Grass Ramp, Grass Pit, Ore, Mountain, Mountain Ramp, Rock, Ice, Snow, Snow Ramp, Sand, Sand Ramp, Stone, Tech, Dirt
+		Voice: Deploying
+		SmartDeploy: true
+	WithMakeAnimation:
+		Sequence: extend
+		BodyNames: deployed
+	WithFacingSpriteBody:
+		RequiresCondition: undeployed
+	WithSpriteBody@DEPLOYED:
+		RequiresCondition: !undeployed
+		Sequence: extended
+		Name: deployed
+	WithRangeCircle:
+		RequiresCondition: deployed
+		Color: 03FE03
+		Width: 2
+		BorderWidth: 3
+		Range: 5c0
 
 JETPACKER:
 	Inherits: ^Helicopter
-	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
+	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Buildable:
 		Queue: Pod
 		Description: actor-jetpacker.description
-		Prerequisites: ~module, techcenter
+		Prerequisites: ~module.sc, techcenter
 		BuildPaletteOrder: 60
 	Encyclopedia:
 		Description: actor-jetpacker.encyclopedia
@@ -344,20 +394,21 @@ JETPACKER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1300
+		Cost: 1125
 	Tooltip:
 		Name: actor-jetpacker.name
 	Health:
-		HP: 9000
+		HP: 13500
 	Aircraft:
 		TurnSpeed: 50
 		CruiseAltitude: 1c0
 		Speed: 100
 		IdealSeparation: 1c0
+		CruiseAltitude: 1800
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Armament:
-		Weapon: HeavyMachineGun
+		Weapon: PodDrunkMissiles
 		MuzzleSequence: muzzle
 		LocalOffset: 0,-300,0,   0,300,0
 	AttackFrontal:
@@ -367,6 +418,50 @@ JETPACKER:
 	WithMoveAnimation:
 	-FireWarheadsOnDeath@SpawnPilot:
 	-GrantRandomCondition@SpawnPilot:
+	RevealsShroud:
+		Range: 8c0
+		MinRange: 4c0
+		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 4c0
+		Type: GroundPosition
+	Voiced:
+		VoiceSet: JetpackerVoice
+
+JETFOILER:
+	Inherits: ^Hovercraft
+	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Buildable:
+		Queue: Pod
+		Description: actor-jetfoiler.description
+		Prerequisites: ~module.yi, techcenter
+		BuildPaletteOrder: 60
+	Encyclopedia:
+		Description: actor-jetfoiler.encyclopedia
+		Order: 40
+		Category: Pods
+	Valued:
+		Cost: 1125
+	Tooltip:
+		Name: actor-jetfoiler.name
+	Health:
+		HP: 10800
+	Aircraft:
+		TurnSpeed: 60
+		CruiseAltitude: 1c0
+		Speed: 180
+		IdealSeparation: 1c0
+		CruiseAltitude: 1800
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Armament:
+		Weapon: HeavyMortarGun
+	AttackFrontal:
+		FacingTolerance: 10
+		Voice: Attack
+	WithMuzzleOverlay:
+	WithMoveAnimation:
 	RevealsShroud:
 		Range: 8c0
 		MinRange: 4c0
@@ -392,11 +487,11 @@ BLASTER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1200
+		Cost: 800
 	Tooltip:
 		Name: actor-blaster.name
 	Health:
-		HP: 10000
+		HP: 20000
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	RevealsShroud:
@@ -426,8 +521,8 @@ BLASTER:
 	KillsSelf:
 		RequiresCondition: triggered
 	AutoTarget:
-		ScanRadius: 5
-		InitialStance: HoldFire
+		ScanRadius: 7
+		InitialStance: Defend
 	-WithDeathAnimation:
 
 SHOCKER:
@@ -458,16 +553,27 @@ SHOCKER:
 	RevealsShroud@Hacked:
 		Range: 3c0
 	Armament@Primary:
-		Weapon: PodVoltageArc
+		Name: primary
+		Weapon: PodVoltageArcGround
 		LocalOffset: 350,0,0
-	Armament@Garrisoned:
+	Armament@Secondary:
+		Name: secondary
+		Weapon: PodVoltageArcAir
+		LocalOffset: 350,0,0
+	Armament@Garrisoned@Primary:
 		Name: garrisoned
-		Weapon: RapidPodVoltageArc
+		Weapon: RapidPodVoltageArcGround
+	Armament@Garrisoned@Secondary:
+		Name: garrisoned
+		Weapon: RapidPodVoltageArcAir
 	AttackFrontal:
 		PauseOnCondition: jammed
 		FacingTolerance: 0
 		Voice: Attack
-	WithAttackAnimation:
+	WithAttackAnimation@Primary:
+		Sequence: shoot
+	WithAttackAnimation@Secondary:
+		Armament: secondary
 		Sequence: shoot
 
 MINIPOD1:

--- a/mods/hv/rules/infantry.yaml
+++ b/mods/hv/rules/infantry.yaml
@@ -401,7 +401,6 @@ JETPACKER:
 		HP: 13500
 	Aircraft:
 		TurnSpeed: 50
-		CruiseAltitude: 1c0
 		Speed: 100
 		IdealSeparation: 1c0
 		CruiseAltitude: 1800
@@ -449,7 +448,6 @@ JETFOILER:
 		HP: 10800
 	Aircraft:
 		TurnSpeed: 60
-		CruiseAltitude: 1c0
 		Speed: 180
 		IdealSeparation: 1c0
 		CruiseAltitude: 1800

--- a/mods/hv/rules/infantry.yaml
+++ b/mods/hv/rules/infantry.yaml
@@ -171,11 +171,11 @@ SNIPER:
 		Voice: Attack
 	WithMuzzleOverlay:
 	Cloak:
-		InitialDelay: 250
-		CloakDelay: 120
+		InitialDelay: 200
+		CloakDelay: 200
 		CloakSound: stealth_on_humanoide9000.ogg
 		UncloakSound: stealth_off_humanoide9000.ogg
-		UncloakOn: Attack, Unload, Move
+		UncloakOn: Attack, Unload
 		PauseOnCondition: cloak-force-disabled || jammed
 		IsPlayerPalette: true
 		CloakedPalette: cloak

--- a/mods/hv/rules/infantry.yaml
+++ b/mods/hv/rules/infantry.yaml
@@ -6,7 +6,7 @@ RIFLEMAN:
 	Buildable:
 		Queue: Pod
 		Description: actor-rifleman.description
-		Prerequisites: ~module
+		Prerequisites: ~disabled
 		BuildPaletteOrder: 10
 	Encyclopedia:
 		Description: actor-rifleman.encyclopedia
@@ -67,12 +67,20 @@ ROCKETEER:
 	RevealsShroud@Hacked:
 		Range: 3c0
 	Armament@Primary:
-		Weapon: LightPodRocket
+		Weapon: LightPodRocketGround
 		MuzzleSequence: muzzle
 		LocalOffset: 50,0,0
-	Armament@Garrisoned:
+	Armament@Secondary:
+		Weapon: LightPodRocketAir
+		MuzzleSequence: muzzle
+		LocalOffset: 50,0,0
+	Armament@Garrisoned@Primary:
 		Name: garrisoned
-		Weapon: RapidPodRocket
+		Weapon: RapidPodRocketGround
+		MuzzleSequence: muzzle
+	Armament@Garrisoned@Secondary:
+		Name: garrisoned
+		Weapon: RapidPodRocketAir
 		MuzzleSequence: muzzle
 	AttackFrontal:
 		PauseOnCondition: jammed
@@ -86,8 +94,8 @@ MORTAR:
 	Buildable:
 		Queue: Pod
 		Description: actor-mortar.description
-		Prerequisites: ~module.sc, factory
-		BuildPaletteOrder: 50
+		Prerequisites: ~module.sc
+		BuildPaletteOrder: 10
 	Encyclopedia:
 		Description: actor-mortar.encyclopedia
 		Order: 35
@@ -127,24 +135,23 @@ SNIPER:
 	Buildable:
 		Queue: Pod
 		Description: actor-sniper.description
-		Prerequisites: ~module.yi, radar
-		BuildPaletteOrder: 50
+		Prerequisites: ~module.yi
+		BuildPaletteOrder: 10
 	Encyclopedia:
 		Description: actor-sniper.encyclopedia
 		Order: 30
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1000
+		Cost: 600
 	Tooltip:
 		Name: actor-sniper.name
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
-	Health:
-		HP: 15000
 	Mobile:
 		Speed: 70
-		Locomotor: pod
+	Health:
+		HP: 15750
 	RevealsShroud:
 		Range: 10c0
 		MinRange: 5c0
@@ -164,14 +171,18 @@ SNIPER:
 		Voice: Attack
 	WithMuzzleOverlay:
 	Cloak:
-		InitialDelay: 250
-		CloakDelay: 120
-		CloakSound:
-		UncloakSound:
-		UncloakOn: Attack, Unload, Move
+		InitialDelay: 200
+		CloakDelay: 200
+		CloakSound: stealth_on_humanoide9000.ogg
+		UncloakSound: stealth_off_humanoide9000.ogg
+		UncloakOn: Attack, Unload
+		PauseOnCondition: cloak-force-disabled || jammed
 		IsPlayerPalette: true
 		CloakedPalette: cloak
 		CloakStyle: Palette
+	GrantConditionOnDamageState@UNCLOAK:
+		Condition: cloak-force-disabled
+		ValidDamageStates: Critical
 
 FLAMER:
 	Inherits: ^Pod
@@ -179,7 +190,7 @@ FLAMER:
 	Buildable:
 		Queue: Pod
 		Description: actor-flamer.description
-		Prerequisites: ~module.sc, factory
+		Prerequisites: ~module.sc, radar
 		BuildPaletteOrder: 40
 	Encyclopedia:
 		Description: actor-flamer.encyclopedia
@@ -187,15 +198,13 @@ FLAMER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 700
+		Cost: 750
 	Tooltip:
 		Name: actor-flamer.name
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
-	Mobile:
-		Speed: 70
+		HP: 30000
 	RevealsShroud:
 		Range: 5c0
 		MinRange: 2c0
@@ -221,7 +230,7 @@ TECHNICIAN:
 	Buildable:
 		Queue: Pod
 		Description: actor-technician.description
-		Prerequisites: ~module
+		Prerequisites: ~module.sc
 		BuildPaletteOrder: 30
 	Encyclopedia:
 		Description: actor-technician.encyclopedia
@@ -254,7 +263,7 @@ TECHNICIAN:
 	Guard:
 		Voice: Action
 	Health:
-		HP: 12500
+		HP: 18750
 	Mobile:
 		Speed: 70
 	AutoTarget:
@@ -281,15 +290,15 @@ BROKER:
 	Buildable:
 		Queue: Pod
 		Description: actor-broker.description
-		Prerequisites: trader
-		BuildPaletteOrder: 70
+		Prerequisites: ~module.yi
+		BuildPaletteOrder: 30
 	Encyclopedia:
 		Description: actor-broker.encyclopedia
-		Order: 16
+		Order: 15
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1400
+		Cost: 1000
 	Tooltip:
 		Name: actor-broker.name
 	UpdatesPlayerStatistics:
@@ -300,11 +309,23 @@ BROKER:
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 2c0
+	CaptureManager:
+	Captures:
+		CaptureTypes: building
+		PlayerExperience: 25
+		CaptureDelay: 375
+		ConsumedByCapture: false
+		EnterCursor: ability
+		EnterBlockedCursor: move-blocked
+		RequiresCondition: !deployed && !jammed
 	Health:
-		HP: 17500
+		HP: 18750
+	Mobile:
+		Speed: 70
 	Voiced:
 		VoiceSet: BrokerVoice
 	GrantConditionOnAttack:
+		RequiresCondition: deployed
 		Condition: chargeup-wiretransfer
 		RevokeDelay: 220
 		MaximumInstances: 11
@@ -313,14 +334,16 @@ BROKER:
 		IsCyclic: true
 	Armament@PrepareStage1:
 		Weapon: BrokerPrepareWireTransferStage1
-		RequiresCondition: chargeup-wiretransfer < 6
+		RequiresCondition: deployed && chargeup-wiretransfer < 6
 	Armament@PrepareStage2:
 		Weapon: BrokerPrepareWireTransferStage2
-		RequiresCondition: chargeup-wiretransfer > 5 && chargeup-wiretransfer < 11
+		RequiresCondition: deployed && chargeup-wiretransfer > 5 && chargeup-wiretransfer < 11
 	Armament@Steal:
 		Weapon: BrokerWireTransfer
-		RequiresCondition: chargeup-wiretransfer == 11
+		RequiresCondition: deployed && chargeup-wiretransfer == 11
 	AttackFrontal:
+		RequiresCondition: deployed
+		PauseOnCondition: jammed
 		FacingTolerance: 10
 		Voice: Attack
 	AutoTarget:
@@ -329,14 +352,41 @@ BROKER:
 	AutoTargetPriority@Default:
 		ValidTargets: Defraudable
 		InvalidTargets: NoAutoTarget
+	GrantConditionOnDeploy:
+		PauseOnCondition: jammed
+		DeployedCondition: deployed
+		UndeployedCondition: undeployed
+		UndeployOnMove: true
+		UndeployOnPickup: true
+		Facing: 512
+		DeploySounds: broker_deploy_mincedbeats.ogg
+		UndeploySounds: broker_undeploy_mincedbeats.ogg
+		AllowedTerrainTypes: Clear, Road, Crater, Grass, Grass Ramp, Grass Pit, Ore, Mountain, Mountain Ramp, Rock, Ice, Snow, Snow Ramp, Sand, Sand Ramp, Stone, Tech, Dirt
+		Voice: Deploying
+		SmartDeploy: true
+	WithMakeAnimation:
+		Sequence: extend
+		BodyNames: deployed
+	WithFacingSpriteBody:
+		RequiresCondition: undeployed
+	WithSpriteBody@DEPLOYED:
+		RequiresCondition: !undeployed
+		Sequence: extended
+		Name: deployed
+	WithRangeCircle:
+		RequiresCondition: deployed
+		Color: 03FE03
+		Width: 2
+		BorderWidth: 3
+		Range: 5c0
 
 JETPACKER:
 	Inherits: ^Helicopter
-	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
+	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Buildable:
 		Queue: Pod
 		Description: actor-jetpacker.description
-		Prerequisites: ~module, techcenter
+		Prerequisites: ~module.sc, techcenter
 		BuildPaletteOrder: 60
 	Encyclopedia:
 		Description: actor-jetpacker.encyclopedia
@@ -344,20 +394,21 @@ JETPACKER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1300
+		Cost: 1125
 	Tooltip:
 		Name: actor-jetpacker.name
 	Health:
-		HP: 9000
+		HP: 13500
 	Aircraft:
 		TurnSpeed: 50
 		CruiseAltitude: 1c0
 		Speed: 100
 		IdealSeparation: 1c0
+		CruiseAltitude: 1800
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Armament:
-		Weapon: HeavyMachineGun
+		Weapon: PodDrunkMissiles
 		MuzzleSequence: muzzle
 		LocalOffset: 0,-300,0,   0,300,0
 	AttackFrontal:
@@ -367,6 +418,50 @@ JETPACKER:
 	WithMoveAnimation:
 	-FireWarheadsOnDeath@SpawnPilot:
 	-GrantRandomCondition@SpawnPilot:
+	RevealsShroud:
+		Range: 8c0
+		MinRange: 4c0
+		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@Hacked:
+		Range: 4c0
+		Type: GroundPosition
+	Voiced:
+		VoiceSet: JetpackerVoice
+
+JETFOILER:
+	Inherits: ^Hovercraft
+	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Buildable:
+		Queue: Pod
+		Description: actor-jetfoiler.description
+		Prerequisites: ~module.yi, techcenter
+		BuildPaletteOrder: 60
+	Encyclopedia:
+		Description: actor-jetfoiler.encyclopedia
+		Order: 40
+		Category: Pods
+	Valued:
+		Cost: 1125
+	Tooltip:
+		Name: actor-jetfoiler.name
+	Health:
+		HP: 10800
+	Aircraft:
+		TurnSpeed: 60
+		CruiseAltitude: 1c0
+		Speed: 180
+		IdealSeparation: 1c0
+		CruiseAltitude: 1800
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	Armament:
+		Weapon: HeavyMortarGun
+	AttackFrontal:
+		FacingTolerance: 10
+		Voice: Attack
+	WithMuzzleOverlay:
+	WithMoveAnimation:
 	RevealsShroud:
 		Range: 8c0
 		MinRange: 4c0
@@ -392,11 +487,11 @@ BLASTER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1200
+		Cost: 800
 	Tooltip:
 		Name: actor-blaster.name
 	Health:
-		HP: 10000
+		HP: 20000
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	RevealsShroud:
@@ -426,8 +521,8 @@ BLASTER:
 	KillsSelf:
 		RequiresCondition: triggered
 	AutoTarget:
-		ScanRadius: 5
-		InitialStance: HoldFire
+		ScanRadius: 7
+		InitialStance: Defend
 	-WithDeathAnimation:
 
 SHOCKER:
@@ -458,16 +553,27 @@ SHOCKER:
 	RevealsShroud@Hacked:
 		Range: 3c0
 	Armament@Primary:
-		Weapon: PodVoltageArc
+		Name: primary
+		Weapon: PodVoltageArcGround
 		LocalOffset: 350,0,0
-	Armament@Garrisoned:
+	Armament@Secondary:
+		Name: secondary
+		Weapon: PodVoltageArcAir
+		LocalOffset: 350,0,0
+	Armament@Garrisoned@Primary:
 		Name: garrisoned
-		Weapon: RapidPodVoltageArc
+		Weapon: RapidPodVoltageArcGround
+	Armament@Garrisoned@Secondary:
+		Name: garrisoned
+		Weapon: RapidPodVoltageArcAir
 	AttackFrontal:
 		PauseOnCondition: jammed
 		FacingTolerance: 0
 		Voice: Attack
-	WithAttackAnimation:
+	WithAttackAnimation@Primary:
+		Sequence: shoot
+	WithAttackAnimation@Secondary:
+		Armament: secondary
 		Sequence: shoot
 
 MINIPOD1:

--- a/mods/hv/rules/infantry.yaml
+++ b/mods/hv/rules/infantry.yaml
@@ -14,7 +14,7 @@ RIFLEMAN:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 200
+		Cost: 400
 	Tooltip:
 		Name: actor-rifleman.name
 	UpdatesPlayerStatistics:
@@ -55,7 +55,7 @@ ROCKETEER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 450
+		Cost: 900
 	Tooltip:
 		Name: actor-rocketeer.name
 	UpdatesPlayerStatistics:
@@ -102,7 +102,7 @@ MORTAR:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 300
+		Cost: 600
 	Tooltip:
 		Name: actor-mortar.name
 	UpdatesPlayerStatistics:
@@ -143,7 +143,7 @@ SNIPER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 600
+		Cost: 1200
 	Tooltip:
 		Name: actor-sniper.name
 	UpdatesPlayerStatistics:
@@ -198,7 +198,7 @@ FLAMER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 750
+		Cost: 1500
 	Tooltip:
 		Name: actor-flamer.name
 	UpdatesPlayerStatistics:
@@ -238,7 +238,7 @@ TECHNICIAN:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1000
+		Cost: 1500
 	Tooltip:
 		Name: actor-technician.name
 	UpdatesPlayerStatistics:
@@ -298,7 +298,7 @@ BROKER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1000
+		Cost: 1500
 	Tooltip:
 		Name: actor-broker.name
 	UpdatesPlayerStatistics:
@@ -394,7 +394,7 @@ JETPACKER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 1125
+		Cost: 2250
 	Tooltip:
 		Name: actor-jetpacker.name
 	Health:
@@ -441,7 +441,7 @@ JETFOILER:
 		Order: 40
 		Category: Pods
 	Valued:
-		Cost: 1125
+		Cost: 2250
 	Tooltip:
 		Name: actor-jetfoiler.name
 	Health:
@@ -485,7 +485,7 @@ BLASTER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 800
+		Cost: 1600
 	Tooltip:
 		Name: actor-blaster.name
 	Health:
@@ -537,7 +537,7 @@ SHOCKER:
 		Scale: 3
 		Category: Pods
 	Valued:
-		Cost: 450
+		Cost: 900
 	Tooltip:
 		Name: actor-shocker.name
 	Voiced:

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -476,7 +476,7 @@ FERRY:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor
+		Prerequisites: ~harbor.yi
 		BuildPaletteOrder: 20
 		Description: actor-ferry.description
 	Encyclopedia:
@@ -487,13 +487,13 @@ FERRY:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 50000
+		HP: 49500
 	Armor:
 		Type: Heavy
 	Mobile:
 		Locomotor: ferry
-		Speed: 80
-		TurnSpeed: 50
+		Speed: 88
+		TurnSpeed: 55
 	RevealsShroud:
 		Range: 6c0
 		MinRange: 4c0
@@ -505,12 +505,28 @@ FERRY:
 	Cargo:
 		Types: Pod, Vehicle
 		MaxWeight: 10
-		AfterUnloadDelay: 40
+		AfterUnloadDelay: 0
 	WithCargoPipsDecoration:
 		PipCount: 5
 		Position: BottomLeft
 		Margin: 1, -1
 		RequiresSelection: true
+
+FERRY2:
+	Inherits: FERRY
+	Tooltip:
+		Name: actor-ferry2.name
+		GenericName: actor-ferry2.generic-name
+	Buildable:
+		Prerequisites: ~harbor.sc
+		Description: actor-ferry2.description
+	Encyclopedia:
+		Description: actor-ferry2.encyclopedia
+	Health:
+		HP: 60500
+	Mobile:
+		Speed: 72
+		TurnSpeed: 45
 
 MINESHIP:
 	Inherits: ^Ship

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -3,6 +3,7 @@
 LIGHTBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
+	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
 		Cost: 900
 	Tooltip:
@@ -11,7 +12,7 @@ LIGHTBOAT:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.yi
+		Prerequisites: ~harbor.sc
 		BuildPaletteOrder: 10
 		Description: actor-lightboat.description
 	Encyclopedia:
@@ -22,7 +23,7 @@ LIGHTBOAT:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 30000
+		HP: 45000
 	Armor:
 		Type: Light
 	Mobile:
@@ -52,6 +53,7 @@ LIGHTBOAT:
 PATROLBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
+	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
 		Cost: 900
 	Tooltip:
@@ -60,7 +62,7 @@ PATROLBOAT:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.sc
+		Prerequisites: ~harbor.yi
 		BuildPaletteOrder: 10
 		Description: actor-patrolboat.description
 	Encyclopedia:
@@ -71,7 +73,7 @@ PATROLBOAT:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 30000
+		HP: 45000
 	Armor:
 		Type: Light
 	Mobile:
@@ -94,7 +96,6 @@ PATROLBOAT:
 		LocalOffset: 250,-25,50, 250,25,50
 	Armament@Ground:
 		Weapon: BoatMissileAntiGround
-		MuzzleSequence: muzzle
 		Recoil: 100
 		RecoilRecovery: 38
 		LocalOffset: 250,-25,50, 250,25,50
@@ -106,26 +107,27 @@ PATROLBOAT:
 MERCBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
-		Cost: 1600
+		Cost: 1200
 	Tooltip:
 		Name: actor-mercboat.name
 		GenericName: actor-mercboat.generic-name
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~disabled
-		BuildPaletteOrder: 90
+		Prerequisites: ~harbor.sc, radar
+		BuildPaletteOrder: 30
 		Description: actor-mercboat.description
 	Encyclopedia:
 		Description: actor-mercboat.encyclopedia
-		Order: 60
+		Order: 10
 		Scale: 3
 		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 71500
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -137,6 +139,10 @@ MERCBOAT:
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 3c0
+	DetectCloaked:
+		Range: 5c0
+		DetectionTypes: Underwater
+	RenderDetectionCircle:
 	Turreted:
 		TurnSpeed: 60
 		Offset: 150,0,100
@@ -153,6 +159,7 @@ MERCBOAT:
 TORPEDOBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
 		Cost: 1600
 	Tooltip:
@@ -161,18 +168,18 @@ TORPEDOBOAT:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.yi, radar
-		BuildPaletteOrder: 30
+		Prerequisites: ~disabled
+		BuildPaletteOrder: 90
 		Description: actor-torpedoboat.description
 	Encyclopedia:
 		Description: actor-torpedoboat.encyclopedia
-		Order: 10
+		Order: 60
 		Scale: 3
 		Category: Ships
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 67500
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -197,6 +204,7 @@ TORPEDOBOAT:
 SUBMARINE:
 	Inherits: ^Submarine
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
 		Cost: 1600
 	Tooltip:
@@ -205,7 +213,7 @@ SUBMARINE:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.sc, radar
+		Prerequisites: ~harbor.yi, radar
 		BuildPaletteOrder: 30
 		Description: actor-submarine.description
 	Encyclopedia:
@@ -216,7 +224,7 @@ SUBMARINE:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 66000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -241,8 +249,9 @@ SUBMARINE:
 RAILGUNBOAT:
 	Inherits: ^Ship
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
-		Cost: 4000
+		Cost: 5000
 	Tooltip:
 		Name: actor-railgunboat.name
 		GenericName: actor-railgunboat.generic-name
@@ -260,10 +269,11 @@ RAILGUNBOAT:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 60000
+		HP: 90000
 	Armor:
 		Type: Heavy
 	Mobile:
+		RequiresCondition: !deployed
 		Speed: 75
 		TurnSpeed: 40
 		CanMoveBackward: true
@@ -275,19 +285,39 @@ RAILGUNBOAT:
 		Range: 4c0
 	Turreted:
 		TurnSpeed: 40
-	Armament:
+	Armament@Primary:
+		RequiresCondition: !deployed
 		Weapon: Railgun
+		Recoil: 100
+		RecoilRecovery: 25
+		LocalOffset: 500,0,0
+	Armament@Secondary:
+		RequiresCondition: deployed
+		Weapon: RailgunLongRange
 		Recoil: 100
 		RecoilRecovery: 25
 		LocalOffset: 500,0,0
 	AttackTurreted:
 	WithSpriteTurret:
+	GrantConditionOnDeploy:
+		DeployedCondition: deployed
+		UndeployOnMove: true
+		UndeployOnPickup: true
+		Voice: Move
+		SmartDeploy: true
+	WithRangeCircle:
+		RequiresCondition: deployed
+		Color: FE03FE
+		Type: Turret
+		Width: 2
+		BorderWidth: 3
+		Range: 10c0
 
 LIGHTNINGBOAT:
 	Inherits: ^Ship
-	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
-		Cost: 4000
+		Cost: 4500
 	Tooltip:
 		Name: actor-lightningboat.name
 		GenericName: actor-lightningboat.generic-name
@@ -305,7 +335,7 @@ LIGHTNINGBOAT:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 60000
+		HP: 90000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -313,34 +343,34 @@ LIGHTNINGBOAT:
 		TurnSpeed: 40
 		CanMoveBackward: true
 	RevealsShroud:
-		Range: 9c0
-		MinRange: 4c0
+		Range: 4c0
+		MinRange: 2c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
+		Range: 2c0
+	WithRangeCircle:
+		Color: 9999FA
+		Width: 2
+		BorderWidth: 3
 		Range: 4c0
-	Turreted:
-		TurnSpeed: 40
-	Armament:
-		Weapon: VoltageArc
-		LocalOffset: 0,0,100
-	AttackTurreted:
-	WithAttackAnimation:
-		Sequence: shoot
-	WithAttackOverlay:
-		Sequence: charge
+	ProximityExternalCondition:
+		Condition: lightningboat-reloaddelay-increase
+		Range: 4c0
+	ExternalCondition:
+		Condition: lightningboat-reloaddelay-increase
 
 BOOMER:
 	Inherits: ^Submarine
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 5000
+		Cost: 6250
 	Tooltip:
 		Name: actor-boomer.name
 		GenericName: actor-boomer.generic-name
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Ship
-		Prerequisites: ~harbor.sc, techcenter
+		Prerequisites: ~harbor.yi, techcenter
 		BuildPaletteOrder: 60
 		Description: actor-boomer.description
 	Encyclopedia:
@@ -351,7 +381,7 @@ BOOMER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 80000
+		HP: 120000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -389,7 +419,7 @@ SLCM:
 	Tooltip:
 		Name: actor-slcm-name
 	Health:
-		HP: 5000
+		HP: 7500
 	Armor:
 		Type: Light
 	BallisticMissile:
@@ -402,7 +432,7 @@ SLCM:
 		HitAcceleration: 0
 		LaunchSounds: missile_julien-nicolas.ogg
 	LeavesTrails:
-		Image: smoke
+		Image: stealthtank-trail
 		MovingInterval: 2
 		Type: CenterPosition
 		SpawnAtLastPosition: false
@@ -417,7 +447,7 @@ CARRIER:
 	Buildable:
 		Queue: Ship
 		BuildPaletteOrder: 60
-		Prerequisites: ~harbor.yi, techcenter
+		Prerequisites: ~harbor.sc, techcenter
 		Description: actor-carrier.description
 	Encyclopedia:
 		Description: actor-carrier.encyclopedia
@@ -425,11 +455,11 @@ CARRIER:
 		Scale: 3
 		Category: Ships
 	Valued:
-		Cost: 5000
+		Cost: 6250
 	Tooltip:
 		Name: actor-carrier.name
 	Health:
-		HP: 80000
+		HP: 120000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -487,7 +517,7 @@ FERRY:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 49500
+		HP: 74250
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -523,7 +553,7 @@ FERRY2:
 	Encyclopedia:
 		Description: actor-ferry2.encyclopedia
 	Health:
-		HP: 60500
+		HP: 90750
 	Mobile:
 		Speed: 72
 		TurnSpeed: 45
@@ -550,7 +580,7 @@ MINESHIP:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 21000
+		HP: 31500
 	Armor:
 		Type: Light
 	Mobile:

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -30,11 +30,11 @@ LIGHTBOAT:
 		Speed: 125
 		TurnSpeed: 60
 	RevealsShroud:
-		Range: 9c0
-		MinRange: 4c0
+		Range: 10c0
+		MinRange: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 5c0
 	Turreted:
 		TurnSpeed: 120
 	Armament@Air:
@@ -80,11 +80,11 @@ PATROLBOAT:
 		Speed: 125
 		TurnSpeed: 60
 	RevealsShroud:
-		Range: 9c0
-		MinRange: 4c0
+		Range: 10c0
+		MinRange: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 5c0
 	Turreted:
 		TurnSpeed: 120
 		Offset: 300,0,0

--- a/mods/hv/rules/ships.yaml
+++ b/mods/hv/rules/ships.yaml
@@ -5,7 +5,7 @@ LIGHTBOAT:
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
-		Cost: 900
+		Cost: 1800
 	Tooltip:
 		Name: actor-lightboat.name
 		GenericName: actor-lightboat.generic-name
@@ -55,7 +55,7 @@ PATROLBOAT:
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
-		Cost: 900
+		Cost: 1800
 	Tooltip:
 		Name: actor-patrolboat.name
 		GenericName: actor-patrolboat.generic-name
@@ -109,7 +109,7 @@ MERCBOAT:
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
-		Cost: 1200
+		Cost: 2400
 	Tooltip:
 		Name: actor-mercboat.name
 		GenericName: actor-mercboat.generic-name
@@ -161,7 +161,7 @@ TORPEDOBOAT:
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
-		Cost: 1600
+		Cost: 3200
 	Tooltip:
 		Name: actor-torpedoboat.name
 		GenericName: actor-torpedoboat.generic-name
@@ -206,7 +206,7 @@ SUBMARINE:
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
-		Cost: 1600
+		Cost: 3200
 	Tooltip:
 		Name: actor-submarine.name
 		GenericName: actor-submarine.generic-name
@@ -251,7 +251,7 @@ RAILGUNBOAT:
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
-		Cost: 5000
+		Cost: 10000
 	Tooltip:
 		Name: actor-railgunboat.name
 		GenericName: actor-railgunboat.generic-name
@@ -317,7 +317,7 @@ LIGHTNINGBOAT:
 	Inherits: ^Ship
 	Inherits@Amplifier: ^WeaponReloadDelayUpgrade
 	Valued:
-		Cost: 4500
+		Cost: 9000
 	Tooltip:
 		Name: actor-lightningboat.name
 		GenericName: actor-lightningboat.generic-name
@@ -363,7 +363,7 @@ BOOMER:
 	Inherits: ^Submarine
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 6250
+		Cost: 12500
 	Tooltip:
 		Name: actor-boomer.name
 		GenericName: actor-boomer.generic-name
@@ -455,7 +455,7 @@ CARRIER:
 		Scale: 3
 		Category: Ships
 	Valued:
-		Cost: 6250
+		Cost: 12500
 	Tooltip:
 		Name: actor-carrier.name
 	Health:
@@ -499,7 +499,7 @@ CARRIER:
 FERRY:
 	Inherits: ^Ship
 	Valued:
-		Cost: 1400
+		Cost: 2800
 	Tooltip:
 		Name: actor-ferry.name
 		GenericName: actor-ferry.generic-name
@@ -562,7 +562,7 @@ MINESHIP:
 	Inherits: ^Ship
 	Inherits@Selection: ^SelectableSupportUnit
 	Valued:
-		Cost: 1400
+		Cost: 2100
 	Tooltip:
 		Name: actor-mineship.name
 		GenericName: actor-mineship.generic-name

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -92,11 +92,11 @@ AATANK:
 		Speed: 115
 		Locomotor: wheeled
 	RevealsShroud:
-		Range: 8c0
-		MinRange: 4c0
+		Range: 10c0
+		MinRange: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 5c0
 	Turreted:
 		TurnSpeed: 40
 		Offset: 0,0,200
@@ -942,11 +942,11 @@ MISSILETANK:
 		TurnSpeed: 30
 		Speed: 80
 	RevealsShroud:
-		Range: 9c0
-		MinRange: 4c0
+		Range: 10c0
+		MinRange: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 5c0
 	Turreted:
 		TurnSpeed: 40
 		Offset: -200,-50,100

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -132,14 +132,14 @@ AATANK2:
 
 APC:
 	Inherits: ^TrackedVehicle
-	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
 		Cost: 1200
 	Tooltip:
 		Name: actor-apc.name
 	Buildable:
 		Queue: Tank
-		Prerequisites: factory, module
+		Prerequisites: ~factory.yi, module
 		BuildPaletteOrder: 40
 		Description: actor-apc.description
 	Encyclopedia:
@@ -150,11 +150,12 @@ APC:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 25000
+		HP: 31500
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 110
+		TurnSpeed: 28
+		Speed: 121
 		PauseOnCondition: loading || jammed
 	RevealsShroud:
 		Range: 6c0
@@ -166,6 +167,7 @@ APC:
 		Types: Pod
 		MaxWeight: 5
 		LoadingCondition: loading
+		AfterUnloadDelay: 0
 		PassengerConditions:
 			rifleman: loaded
 			rocketeer: loaded
@@ -192,6 +194,21 @@ APC:
 	FireWarheadsOnDeath:
 		Weapon: UnitExplodeLarge
 		EmptyWeapon: UnitExplodeLarge
+
+APC2:
+	Inherits: APC
+	Tooltip:
+		Name: actor-apc2.name
+	Buildable:
+		Prerequisites: ~factory.sc, module
+		Description: actor-apc2.description
+	Encyclopedia:
+		Description: actor-apc2.encyclopedia
+	Health:
+		HP: 38500
+	Mobile:
+		TurnSpeed: 23
+		Speed: 99
 
 ARTILLERY:
 	Inherits: ^TrackedVehicle

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -13,7 +13,7 @@ MBT:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 10
-		Prerequisites: ~factory.yi
+		Prerequisites: ~disabled
 		Queue: Tank
 		Description: actor-mbt.description
 	Encyclopedia:
@@ -25,7 +25,7 @@ MBT:
 		TurnSpeed: 25
 		Speed: 95
 	Health:
-		HP: 46000
+		HP: 69000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -54,7 +54,7 @@ MBT:
 MBT2:
 	Inherits: MBT
 	Buildable:
-		Prerequisites: ~factory.sc
+		Prerequisites: ~disabled
 	-Encyclopedia:
 	Turreted:
 		Offset: 0,0,0
@@ -68,7 +68,7 @@ AATANK:
 	Buildable:
 		Queue: Tank
 		BuildPaletteOrder: 20
-		Prerequisites: ~factory.sc
+		Prerequisites: ~disabled
 		Description: actor-aatank.description
 	Encyclopedia:
 		Description: actor-aatank.encyclopedia
@@ -84,7 +84,7 @@ AATANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: Light
 	Mobile:
@@ -150,7 +150,7 @@ APC:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 31500
+		HP: 47250
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -205,7 +205,7 @@ APC2:
 	Encyclopedia:
 		Description: actor-apc2.encyclopedia
 	Health:
-		HP: 38500
+		HP: 57750
 	Mobile:
 		TurnSpeed: 23
 		Speed: 99
@@ -221,8 +221,8 @@ ARTILLERY:
 		Class: artillery
 	Buildable:
 		Queue: Tank
-		Prerequisites: factory, radar
-		BuildPaletteOrder: 50
+		Prerequisites: ~factory.sc, radar
+		BuildPaletteOrder: 20
 		Description: actor-artillery.description
 	Encyclopedia:
 		Description: actor-artillery.encyclopedia
@@ -232,7 +232,7 @@ ARTILLERY:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: Light
 	Mobile:
@@ -282,7 +282,7 @@ RADARTANK:
 	Selectable:
 		Class: radartank
 	Health:
-		HP: 50000
+		HP: 75000
 	Armor:
 		Type: Light
 	Mobile:
@@ -367,7 +367,7 @@ REPAIRTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 20000
+		HP: 30000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -407,7 +407,7 @@ MINELAYER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 21000
+		HP: 31500
 	Armor:
 		Type: Light
 	Mobile:
@@ -448,7 +448,7 @@ RAILGUNTANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 3000
+		Cost: 3750
 	Tooltip:
 		Name: actor-railguntank.name
 		GenericName: actor-railguntank.generic-name
@@ -465,7 +465,7 @@ RAILGUNTANK:
 		BuildPaletteOrder: 70
 		Description: actor-railguntank.description
 	Armament:
-		Weapon: railgun
+		Weapon: Railgun
 		LocalOffset: 325,450,0
 	AttackFrontal:
 		PauseOnCondition: jammed
@@ -474,7 +474,7 @@ RAILGUNTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 50000
+		HP: 75000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -492,8 +492,8 @@ LIGHTNINGTANK:
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Buildable:
 		Queue: Tank
-		BuildPaletteOrder: 70
-		Prerequisites: ~factory.yi, techcenter
+		BuildPaletteOrder: 10
+		Prerequisites: ~factory.yi
 		Description: actor-lightningtank.description
 	Encyclopedia:
 		Description: actor-lightningtank.encyclopedia
@@ -501,7 +501,7 @@ LIGHTNINGTANK:
 		Scale: 3
 		Category: Tanks
 	Valued:
-		Cost: 3000
+		Cost: 1700
 	Tooltip:
 		Name: actor-lightningtank.name
 		GenericName: actor-lightningtank.generic-name
@@ -509,28 +509,29 @@ LIGHTNINGTANK:
 		Class: lightningtank
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
+	Mobile:
+		TurnSpeed: 25
+		Speed: 95
 	Health:
-		HP: 50000
+		HP: 69000
 	Armor:
 		Type: Heavy
-	Mobile:
-		Speed: 80
-		TurnSpeed: 25
 	RevealsShroud:
-		Range: 9c0
-		MinRange: 4c0
+		Range: 7c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Armament:
-		Weapon: VoltageArc
+		Weapon: TankVoltageArc
 		LocalOffset: 500,0,0
 	AttackFrontal:
 		PauseOnCondition: jammed
 		Voice: Attack
-		FacingTolerance: 0
+		FacingTolerance: 120
 	WithAttackAnimation:
 		Sequence: shoot
+	WithMuzzleOverlay:
 
 STEALTHTANK:
 	Inherits: ^TrackedVehicle
@@ -546,7 +547,7 @@ STEALTHTANK:
 		Scale: 3
 		Category: Tanks
 	Valued:
-		Cost: 2400
+		Cost: 3000
 	Tooltip:
 		Name: actor-stealthtank.name
 	Selectable:
@@ -554,7 +555,7 @@ STEALTHTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 30000
+		HP: 60000
 	Armor:
 		Type: Heavy
 	AttackFrontal:
@@ -620,7 +621,7 @@ MERCTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 67500
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -652,7 +653,7 @@ DUALMERCTANK:
 		Weapon: DoubleCannon
 		LocalOffset: 500,85,50, 500,-85,50
 	Health:
-		HP: 50000
+		HP: 75000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -693,7 +694,7 @@ ECMTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: Light
 	Mobile:
@@ -731,7 +732,7 @@ DUALARTILLERY:
 		Scale: 3
 		Category: Tanks
 	Health:
-		HP: 35000
+		HP: 52500
 	Armor:
 		Type: Light
 	Mobile:
@@ -784,7 +785,7 @@ BUILDER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 12000
+		HP: 18000
 	Armor:
 		Type: Light
 	Mobile:
@@ -835,7 +836,7 @@ COLLECTOR:
 	Selectable:
 		Class: collector
 	Health:
-		HP: 10000
+		HP: 15000
 	Armor:
 		Type: Light
 	Mobile:
@@ -876,7 +877,7 @@ MINER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: Light
 	Mobile:
@@ -913,9 +914,9 @@ MINER:
 
 MISSILETANK:
 	Inherits: ^TrackedVehicle
-	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 2400
+		Cost: 2125
 	Tooltip:
 		Name: actor-missiletank.name
 		GenericName: actor-missiletank.generic-name
@@ -923,8 +924,8 @@ MISSILETANK:
 		Class: missiletank
 	Buildable:
 		Queue: Tank
-		Prerequisites: ~factory.sc, radar, techcenter
-		BuildPaletteOrder: 80
+		Prerequisites: ~factory.sc
+		BuildPaletteOrder: 10
 		Description: actor-missiletank.description
 	Encyclopedia:
 		Description: actor-missiletank.encyclopedia
@@ -934,23 +935,27 @@ MISSILETANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 91500
 	Armor:
 		Type: Heavy
 	Mobile:
+		TurnSpeed: 30
 		Speed: 80
 	RevealsShroud:
-		Range: 7c0
-		MinRange: 3c0
+		Range: 9c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 40
 		Offset: -200,-50,100
-	Armament:
+	Armament@Primary:
 		Weapon: MissileTankRocket
-		LocalOffset: 500,200,0, 500,-200,0, 500,0,0
+		LocalOffset: 500,0,0, 500,-200,0, 500,200,0
+	Armament@Secondary:
+		Weapon: Patriot
+		LocalOffset: 500,0,0
 	AttackTurreted:
 		PauseOnCondition: jammed
 		Voice: Attack
@@ -978,7 +983,7 @@ HACKERTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 17500
+		HP: 26250
 	Armor:
 		Type: Light
 	Mobile:
@@ -1020,7 +1025,7 @@ BUGGY:
 	Inherits: ^Vehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 1000
 	Tooltip:
 		Name: actor-buggy.name
 		GenericName: actor-buggy.generic-name
@@ -1051,7 +1056,7 @@ BUGGY:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 10000
+		HP: 15000
 	Armor:
 		Type: Light
 	Mobile:
@@ -1071,7 +1076,7 @@ BIKE:
 	Inherits: ^Vehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 1000
 	Tooltip:
 		Name: actor-bike.name
 		GenericName: actor-bike.generic-name
@@ -1099,7 +1104,7 @@ BIKE:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 9500
+		HP: 14250
 	Armor:
 		Type: Light
 	Mobile:
@@ -1128,7 +1133,7 @@ TANKER1:
 	Selectable:
 		Class: tanker
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: Light
 	Mobile:
@@ -1188,7 +1193,7 @@ CVIT:
 	Selectable:
 		Class: cvit
 	Health:
-		HP: 11000
+		HP: 16500
 	Armor:
 		Type: Light
 	Mobile:
@@ -1241,7 +1246,7 @@ FIRETRUCK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 60000
+		HP: 90000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -1291,7 +1296,7 @@ WATERTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 60000
+		HP: 90000
 	Armor:
 		Type: Heavy
 	Mobile:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -1063,6 +1063,9 @@ BUGGY:
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 3c0
+	Passenger:
+		CargoType: Vehicle
+		Weight: 2
 
 BIKE:
 	Inherits: ^Vehicle
@@ -1108,6 +1111,9 @@ BIKE:
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
 		Range: 4c0
+	Passenger:
+		CargoType: Vehicle
+		Weight: 2
 
 TANKER1:
 	Inherits: ^Vehicle
@@ -1194,6 +1200,8 @@ CVIT:
 		PlayerExperience: 5
 	SpawnActorOnDeath:
 		Actor: moneycube
+	Passenger:
+		Weight: 2
 
 FIRETRUCK:
 	Inherits: ^Vehicle

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -555,7 +555,7 @@ STEALTHTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 60000
+		HP: 63000
 	Armor:
 		Type: Heavy
 	AttackFrontal:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -4,7 +4,7 @@ MBT:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1700
+		Cost: 3400
 	Tooltip:
 		Name: actor-mbt.name
 	Selectable:
@@ -76,7 +76,7 @@ AATANK:
 		Scale: 3
 		Category: Tanks
 	Valued:
-		Cost: 1000
+		Cost: 2000
 	Tooltip:
 		Name: actor-aatank.name
 	Selectable:
@@ -134,7 +134,7 @@ APC:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 1200
+		Cost: 2400
 	Tooltip:
 		Name: actor-apc.name
 	Buildable:
@@ -214,7 +214,7 @@ ARTILLERY:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1600
+		Cost: 3200
 	Tooltip:
 		Name: actor-artillery.name
 	Selectable:
@@ -276,7 +276,7 @@ RADARTANK:
 		Scale: 3
 		Category: Utilities
 	Valued:
-		Cost: 800
+		Cost: 1200
 	Tooltip:
 		Name: actor-radartank.name
 	Selectable:
@@ -339,7 +339,7 @@ REPAIRTANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1600
+		Cost: 2400
 	Tooltip:
 		Name: actor-repairtank.name
 		GenericName: actor-repairtank.generic-name
@@ -399,7 +399,7 @@ MINELAYER:
 		Scale: 3
 		Category: Utilities
 	Valued:
-		Cost: 1400
+		Cost: 2100
 	Tooltip:
 		Name: actor-minelayer.name
 	Selectable:
@@ -448,7 +448,7 @@ RAILGUNTANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 3750
+		Cost: 7500
 	Tooltip:
 		Name: actor-railguntank.name
 		GenericName: actor-railguntank.generic-name
@@ -501,7 +501,7 @@ LIGHTNINGTANK:
 		Scale: 3
 		Category: Tanks
 	Valued:
-		Cost: 1700
+		Cost: 3400
 	Tooltip:
 		Name: actor-lightningtank.name
 		GenericName: actor-lightningtank.generic-name
@@ -547,7 +547,7 @@ STEALTHTANK:
 		Scale: 3
 		Category: Tanks
 	Valued:
-		Cost: 3000
+		Cost: 6000
 	Tooltip:
 		Name: actor-stealthtank.name
 	Selectable:
@@ -594,7 +594,7 @@ MERCTANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1700
+		Cost: 3400
 	Tooltip:
 		Name: actor-merctank.name
 		GenericName: actor-merctank.generic-name
@@ -663,7 +663,7 @@ DUALMERCTANK:
 ECMTANK:
 	Inherits: ^TrackedVehicle
 	Valued:
-		Cost: 2000
+		Cost: 4000
 	Tooltip:
 		Name: actor-ecmtank.name
 		GenericName: actor-ecmtank.generic-name
@@ -714,7 +714,7 @@ DUALARTILLERY:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 3500
+		Cost: 7000
 	Tooltip:
 		Name: actor-dualartillery.name
 	Selectable:
@@ -916,7 +916,7 @@ MISSILETANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 2125
+		Cost: 4250
 	Tooltip:
 		Name: actor-missiletank.name
 		GenericName: actor-missiletank.generic-name
@@ -975,7 +975,7 @@ HACKERTANK:
 		Scale: 3
 		Category: Tanks
 	Valued:
-		Cost: 2500
+		Cost: 5000
 	Tooltip:
 		Name: actor-hackertank.name
 	Selectable:
@@ -1025,7 +1025,7 @@ BUGGY:
 	Inherits: ^Vehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1000
+		Cost: 2000
 	Tooltip:
 		Name: actor-buggy.name
 		GenericName: actor-buggy.generic-name
@@ -1076,7 +1076,7 @@ BIKE:
 	Inherits: ^Vehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1000
+		Cost: 2000
 	Tooltip:
 		Name: actor-bike.name
 		GenericName: actor-bike.generic-name

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -13,7 +13,7 @@ MBT:
 		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 10
-		Prerequisites: ~factory.yi
+		Prerequisites: ~disabled
 		Queue: Tank
 		Description: actor-mbt.description
 	Encyclopedia:
@@ -25,7 +25,7 @@ MBT:
 		TurnSpeed: 25
 		Speed: 95
 	Health:
-		HP: 46000
+		HP: 69000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -54,7 +54,7 @@ MBT:
 MBT2:
 	Inherits: MBT
 	Buildable:
-		Prerequisites: ~factory.sc
+		Prerequisites: ~disabled
 	-Encyclopedia:
 	Turreted:
 		Offset: 0,0,0
@@ -68,7 +68,7 @@ AATANK:
 	Buildable:
 		Queue: Tank
 		BuildPaletteOrder: 20
-		Prerequisites: ~factory.sc
+		Prerequisites: ~disabled
 		Description: actor-aatank.description
 	Encyclopedia:
 		Description: actor-aatank.encyclopedia
@@ -84,7 +84,7 @@ AATANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: Light
 	Mobile:
@@ -150,7 +150,7 @@ APC:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 31500
+		HP: 47250
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -205,7 +205,7 @@ APC2:
 	Encyclopedia:
 		Description: actor-apc2.encyclopedia
 	Health:
-		HP: 38500
+		HP: 57750
 	Mobile:
 		TurnSpeed: 23
 		Speed: 99
@@ -221,8 +221,8 @@ ARTILLERY:
 		Class: artillery
 	Buildable:
 		Queue: Tank
-		Prerequisites: factory, radar
-		BuildPaletteOrder: 50
+		Prerequisites: ~factory.sc, radar
+		BuildPaletteOrder: 20
 		Description: actor-artillery.description
 	Encyclopedia:
 		Description: actor-artillery.encyclopedia
@@ -232,7 +232,7 @@ ARTILLERY:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: Light
 	Mobile:
@@ -282,7 +282,7 @@ RADARTANK:
 	Selectable:
 		Class: radartank
 	Health:
-		HP: 50000
+		HP: 75000
 	Armor:
 		Type: Light
 	Mobile:
@@ -367,7 +367,7 @@ REPAIRTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 20000
+		HP: 30000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -407,7 +407,7 @@ MINELAYER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 21000
+		HP: 31500
 	Armor:
 		Type: Light
 	Mobile:
@@ -448,7 +448,7 @@ RAILGUNTANK:
 	Inherits: ^TrackedVehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 3000
+		Cost: 3750
 	Tooltip:
 		Name: actor-railguntank.name
 		GenericName: actor-railguntank.generic-name
@@ -465,7 +465,7 @@ RAILGUNTANK:
 		BuildPaletteOrder: 70
 		Description: actor-railguntank.description
 	Armament:
-		Weapon: railgun
+		Weapon: Railgun
 		LocalOffset: 325,450,0
 	AttackFrontal:
 		PauseOnCondition: jammed
@@ -474,7 +474,7 @@ RAILGUNTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 50000
+		HP: 75000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -492,8 +492,8 @@ LIGHTNINGTANK:
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Buildable:
 		Queue: Tank
-		BuildPaletteOrder: 70
-		Prerequisites: ~factory.yi, techcenter
+		BuildPaletteOrder: 10
+		Prerequisites: ~factory.yi
 		Description: actor-lightningtank.description
 	Encyclopedia:
 		Description: actor-lightningtank.encyclopedia
@@ -501,7 +501,7 @@ LIGHTNINGTANK:
 		Scale: 3
 		Category: Tanks
 	Valued:
-		Cost: 3000
+		Cost: 1700
 	Tooltip:
 		Name: actor-lightningtank.name
 		GenericName: actor-lightningtank.generic-name
@@ -509,28 +509,29 @@ LIGHTNINGTANK:
 		Class: lightningtank
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
+	Mobile:
+		TurnSpeed: 25
+		Speed: 95
 	Health:
-		HP: 50000
+		HP: 69000
 	Armor:
 		Type: Heavy
-	Mobile:
-		Speed: 80
-		TurnSpeed: 25
 	RevealsShroud:
-		Range: 9c0
-		MinRange: 4c0
+		Range: 7c0
+		MinRange: 3c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 4c0
+		Range: 3c0
 	Armament:
-		Weapon: VoltageArc
+		Weapon: TankVoltageArc
 		LocalOffset: 500,0,0
 	AttackFrontal:
 		PauseOnCondition: jammed
 		Voice: Attack
-		FacingTolerance: 0
+		FacingTolerance: 120
 	WithAttackAnimation:
 		Sequence: shoot
+	WithMuzzleOverlay:
 
 STEALTHTANK:
 	Inherits: ^TrackedVehicle
@@ -546,7 +547,7 @@ STEALTHTANK:
 		Scale: 3
 		Category: Tanks
 	Valued:
-		Cost: 2400
+		Cost: 3000
 	Tooltip:
 		Name: actor-stealthtank.name
 	Selectable:
@@ -554,7 +555,7 @@ STEALTHTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 30000
+		HP: 63000
 	Armor:
 		Type: Heavy
 	AttackFrontal:
@@ -620,7 +621,7 @@ MERCTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 67500
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -652,7 +653,7 @@ DUALMERCTANK:
 		Weapon: DoubleCannon
 		LocalOffset: 500,85,50, 500,-85,50
 	Health:
-		HP: 50000
+		HP: 75000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -693,7 +694,7 @@ ECMTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: Light
 	Mobile:
@@ -731,7 +732,7 @@ DUALARTILLERY:
 		Scale: 3
 		Category: Tanks
 	Health:
-		HP: 35000
+		HP: 52500
 	Armor:
 		Type: Light
 	Mobile:
@@ -784,7 +785,7 @@ BUILDER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 12000
+		HP: 18000
 	Armor:
 		Type: Light
 	Mobile:
@@ -835,7 +836,7 @@ COLLECTOR:
 	Selectable:
 		Class: collector
 	Health:
-		HP: 10000
+		HP: 15000
 	Armor:
 		Type: Light
 	Mobile:
@@ -876,7 +877,7 @@ MINER:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: Light
 	Mobile:
@@ -913,9 +914,9 @@ MINER:
 
 MISSILETANK:
 	Inherits: ^TrackedVehicle
-	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
+	Inherits@AutoTarget: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 2400
+		Cost: 2125
 	Tooltip:
 		Name: actor-missiletank.name
 		GenericName: actor-missiletank.generic-name
@@ -923,8 +924,8 @@ MISSILETANK:
 		Class: missiletank
 	Buildable:
 		Queue: Tank
-		Prerequisites: ~factory.sc, radar, techcenter
-		BuildPaletteOrder: 80
+		Prerequisites: ~factory.sc
+		BuildPaletteOrder: 10
 		Description: actor-missiletank.description
 	Encyclopedia:
 		Description: actor-missiletank.encyclopedia
@@ -934,23 +935,27 @@ MISSILETANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 91500
 	Armor:
 		Type: Heavy
 	Mobile:
+		TurnSpeed: 30
 		Speed: 80
 	RevealsShroud:
-		Range: 7c0
-		MinRange: 3c0
+		Range: 9c0
+		MinRange: 4c0
 		RevealGeneratedShroud: False
 	RevealsShroud@Hacked:
-		Range: 3c0
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 40
 		Offset: -200,-50,100
-	Armament:
+	Armament@Primary:
 		Weapon: MissileTankRocket
-		LocalOffset: 500,200,0, 500,-200,0, 500,0,0
+		LocalOffset: 500,0,0, 500,-200,0, 500,200,0
+	Armament@Secondary:
+		Weapon: Patriot
+		LocalOffset: 500,0,0
 	AttackTurreted:
 		PauseOnCondition: jammed
 		Voice: Attack
@@ -978,7 +983,7 @@ HACKERTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 17500
+		HP: 26250
 	Armor:
 		Type: Light
 	Mobile:
@@ -1020,7 +1025,7 @@ BUGGY:
 	Inherits: ^Vehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 1000
 	Tooltip:
 		Name: actor-buggy.name
 		GenericName: actor-buggy.generic-name
@@ -1051,7 +1056,7 @@ BUGGY:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 10000
+		HP: 15000
 	Armor:
 		Type: Light
 	Mobile:
@@ -1071,7 +1076,7 @@ BIKE:
 	Inherits: ^Vehicle
 	Inherits@AutoTarget: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 800
+		Cost: 1000
 	Tooltip:
 		Name: actor-bike.name
 		GenericName: actor-bike.generic-name
@@ -1099,7 +1104,7 @@ BIKE:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 9500
+		HP: 14250
 	Armor:
 		Type: Light
 	Mobile:
@@ -1128,7 +1133,7 @@ TANKER1:
 	Selectable:
 		Class: tanker
 	Health:
-		HP: 15000
+		HP: 22500
 	Armor:
 		Type: Light
 	Mobile:
@@ -1188,7 +1193,7 @@ CVIT:
 	Selectable:
 		Class: cvit
 	Health:
-		HP: 11000
+		HP: 16500
 	Armor:
 		Type: Light
 	Mobile:
@@ -1241,7 +1246,7 @@ FIRETRUCK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 60000
+		HP: 90000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -1291,7 +1296,7 @@ WATERTANK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 60000
+		HP: 90000
 	Armor:
 		Type: Heavy
 	Mobile:

--- a/mods/hv/sequences/infantry.yaml
+++ b/mods/hv/sequences/infantry.yaml
@@ -143,6 +143,17 @@ broker:
 		Length: 7
 		Tick: 80
 		Offset: 0,-2
+	extend:
+		Filename: broker.png
+		Start: 8
+		Length: 7
+		Tick: 60
+	extended:
+		Filename: broker.png
+		Start: 14
+		Length: 4
+		Reverses: true
+		Tick: 60
 	icon:
 		Filename: broker-icon.png
 
@@ -206,6 +217,61 @@ jetpacker:
 		ZOffset: 1024
 	icon:
 		Filename: jetpacker-icon.png
+
+jetfoiler:
+	idle:
+		Filename: ship2.png
+		Facings: 8
+	move:
+		Filename: ship2.png
+		Facings: 8
+	muzzle:
+		Combine:
+			0: #N
+				Filename: artlflsh.png
+				Start: 0
+				Length: 3
+				Offset: -1,3
+			1: #NW
+				Filename: artlflsh.png
+				Start: 3
+				Length: 3
+				Offset: -2,4
+			2: #W
+				Filename: artlflsh.png
+				Start: 6
+				Length: 3
+				Offset: 0,3
+			3: #SW
+				Filename: artlflsh.png
+				Start: 9
+				Length: 3
+				Offset: 0,-2
+			4: #S
+				Filename: artlflsh.png
+				Start: 12
+				Length: 3
+				Offset: -1,-2
+			5: #SE
+				Filename: artlflsh.png
+				Start: 15
+				Length: 3
+				Offset: 0,-2
+			6: #E
+				Filename: artlflsh.png
+				Start: 18
+				Length: 3
+				Offset: 0,3
+			7: #NE
+				Filename: artlflsh.png
+				Start: 21
+				Length: 3
+				Offset: 2,4
+		Length: 3
+		Facings: 8
+		Tick: 50
+	icon:
+		Filename: ship2-icon.png
 
 blaster:
 	idle:

--- a/mods/hv/sequences/ships.yaml
+++ b/mods/hv/sequences/ships.yaml
@@ -137,6 +137,7 @@ watertrail:
 		Tick: 80
 		ZOffset: -2048
 
+# TODO: Change one of them both below later
 ferry:
 	idle:
 		Filename: ferry.png
@@ -155,6 +156,27 @@ ferry:
 		ZOffset: -511
 	icon:
 		Filename: ferry-icon.png
+		Offset: 2, 0
+
+ferry2:
+	idle:
+		Filename: bits/ferry.png
+	open:
+		Filename: bits/ferry.png
+		Length: 4
+		Tick: 150
+	close:
+		Filename: bits/ferry.png
+		Frames: 3, 2, 1, 0
+		Length: 4
+		Tick: 150
+	unload:
+		Filename: bits/ferry.png
+		Start: 3
+		ZOffset: -511
+	icon:
+		Filename: bits/units-icons.png
+		Start: 56
 		Offset: 2, 0
 
 mineship:

--- a/mods/hv/sequences/ships.yaml
+++ b/mods/hv/sequences/ships.yaml
@@ -160,23 +160,22 @@ ferry:
 
 ferry2:
 	idle:
-		Filename: bits/ferry.png
+		Filename: ferry.png
 	open:
-		Filename: bits/ferry.png
+		Filename: ferry.png
 		Length: 4
 		Tick: 150
 	close:
-		Filename: bits/ferry.png
+		Filename: ferry.png
 		Frames: 3, 2, 1, 0
 		Length: 4
 		Tick: 150
 	unload:
-		Filename: bits/ferry.png
+		Filename: ferry.png
 		Start: 3
 		ZOffset: -511
 	icon:
-		Filename: bits/units-icons.png
-		Start: 56
+		Filename: ferry-icon.png
 		Offset: 2, 0
 
 mineship:
@@ -210,6 +209,7 @@ mineship2:
 lightningboat:
 	idle:
 		Filename: lightningboat.png
+	# TODO: Maybe unify idle, shoot and charge animations?
 	shoot:
 		Filename: lightningboat.png
 		Start: 1

--- a/mods/hv/sequences/vehicles.yaml
+++ b/mods/hv/sequences/vehicles.yaml
@@ -346,12 +346,21 @@ repairtank:
 	icon:
 		Filename: repairtank-icon.png
 
+# TODO: Change one of them both below later
 apc:
 	idle:
 		Filename: apc.png
 		Facings: 8
 	icon:
 		Filename: apc-icon.png
+
+apc2:
+	idle:
+		Filename: bits/apc.png
+		Facings: 8
+	icon:
+		Filename: bits/units-icons.png
+		Start: 13
 
 artillery:
 	idle:

--- a/mods/hv/sequences/vehicles.yaml
+++ b/mods/hv/sequences/vehicles.yaml
@@ -356,11 +356,10 @@ apc:
 
 apc2:
 	idle:
-		Filename: bits/apc.png
+		Filename: apc.png
 		Facings: 8
 	icon:
-		Filename: bits/units-icons.png
-		Start: 13
+		Filename: apc-icon.png
 
 artillery:
 	idle:

--- a/mods/hv/sequences/weapons.yaml
+++ b/mods/hv/sequences/weapons.yaml
@@ -175,7 +175,7 @@ bullet10:
 
 slcm:
 	idle:
-		Filename: bullet11.png
+		Filename: bullet8.png
 		Facings: 8
 		InterpolatedFacings: 16
 		ZOffset: 2030

--- a/mods/hv/weapons/ballistics.yaml
+++ b/mods/hv/weapons/ballistics.yaml
@@ -324,7 +324,7 @@ TurretArtillery:
 		Image: bullet2
 		Shadow: true
 	Warhead@Damage: SpreadDamage
-		Damage: 25000
+		Damage: 37500
 		Spread: 850
 		Versus:
 			None: 150
@@ -333,7 +333,7 @@ TurretArtillery:
 			Heavy: 60
 			Wood: 40
 	Warhead@Incendiary: TreeDamage
-		Damage: 25000
+		Damage: 37500
 		Spread: 850
 		Percentage: 40
 	Warhead@Effect: CreateEffect

--- a/mods/hv/weapons/ballistics.yaml
+++ b/mods/hv/weapons/ballistics.yaml
@@ -19,10 +19,10 @@
 		Spread: 128
 		Damage: 4000
 		Versus:
-			None: 20
+			None: 80
 			Steel: 75
 			Light: 100
-			Heavy: 130
+			Heavy: 150
 			Wood: 75
 	Warhead@Incendiary: TreeDamage
 		Damage: 4000
@@ -39,12 +39,12 @@ TankCannon:
 CannonSynapol:
 	Inherits: ^Cannon
 	Projectile: Bullet
-		Image: bullet1
+		Image: bullet5
 
 CannonYuruki:
 	Inherits: ^Cannon
 	Projectile: Bullet
-		Image: bullet5
+		Image: bullet1
 
 ^Artillery:
 	Inherits: ^Cannon
@@ -83,11 +83,80 @@ SmallArtillery:
 	MinRange: 4c0
 	TargetActorCenter: true
 	Projectile: Bullet
+		Image: bullet5
 		Inaccuracy: 1c138
 	Warhead@Damage: SpreadDamage
 		Falloff: 100, 55, 20, 5
 		Versus:
 			None: 60
+
+SmallArtilleryLongDistance:
+	Inherits: SmallArtillery
+	MinRange: 6c0
+	Range: 18c0
+	ReloadDelay: 170
+	Projectile: Bullet
+		Image: bullet3
+		Inaccuracy: 3c138
+
+ArtilleryCluster:
+	Inherits: SmallArtillery
+	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	Report: blaster_flyingsaucerinvasion.ogg
+	ReloadDelay: 170
+	Burst: 6
+	BurstDelays: 5
+	MinRange: 4c0
+	Range: 12c0
+	Projectile: Bullet
+		Inaccuracy: 0c256
+		Image: bullet12
+		Shadow: false
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		Spread: 426
+		Damage: 2300
+		Versus:
+			Steel: 30
+			Concrete: 30
+	Warhead@Cluster: FireCluster
+		Weapon: ClusterProjectileArtillery
+		RandomClusterCount: -1
+		Dimensions: 3,3
+		Footprint: xxx xXx xxx
+		AirThreshold: 0c0
+	Warhead@Effect: CreateEffect
+		Explosions: small
+		ImpactSounds: explosion06.ogg
+		ImpactActors: false
+
+ClusterProjectileArtillery:
+	Inherits: BigSplash
+	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	ReloadDelay: 25
+	Range: 8c0
+	Projectile: Bullet
+		Speed: 250
+		Inaccuracy: 0c512
+		Image: bullet3
+		Shadow: false
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		Spread: 128
+		Damage: 2500
+		Versus:
+			None: 50
+			Steel: 25
+			Light: 50
+			Heavy: 50
+			Concrete: 25
+	Warhead@Incendiary: TreeDamage
+		Spread: 128
+		Damage: 2500
+	Warhead@GroundEffect: CreateEffect
+		Explosions: small
+		ValidTargets: Ground
+		ImpactSounds: explosion06.ogg
 
 DoubleBarrelledArtillery:
 	Inherits: ^Artillery
@@ -308,31 +377,30 @@ DoubleCannon:
 MortarGun:
 	Inherits: SmallSplash
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
-	ReloadDelay: 50
+	ReloadDelay: 49
 	Report: grenade-launcher_lemudcrab.ogg
-	Range: 6c0
-	MinRange: 1c0
+	Range: 7c0
 	Projectile: Bullet
 		Image: bullet1
 		Speed: 360
 		Blockable: false
 		LaunchAngle: 80
-		Inaccuracy: 0c512
 		ContrailLength: 10
 		ContrailStartColor: 811000
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
 		ValidTargets: Ground, Water, Tree, Lava, Swamp
-		Spread: 256
+		Spread: 128
 		Damage: 6000
 		Versus:
 			None: 70
-			Steel: 40
+			Steel: 15
 			Light: 25
 			Heavy: 25
 			Wood: 75
+			Concrete: 15
 	Warhead@Incendiary: TreeDamage
-		Spread: 256
+		Spread: 128
 		Damage: 6000
 		Percentage: 75
 	Warhead@Smudge: LeaveSmudge
@@ -345,9 +413,77 @@ MortarGun:
 
 BunkerMortarGun:
 	Inherits: MortarGun
-	Range: 9c0
+	Range: 10c0
 	ReloadDelay: 25
 	MinRange: 0
+
+HeavyMortarGun:
+	Inherits: SmallArtillery
+	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	Report: ccbygrenadelaunch01.ogg
+	Range: 6c0
+	MinRange: 1c0
+	Projectile: Bullet
+		Image: bullet12
+		LaunchAngle: 40
+		Inaccuracy: 512
+		ContrailStartColor: 9bc2eb
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		ValidTargets: Water, Ground, Tree, Lava, Swamp
+		Spread: 256
+		Damage: 300
+		Versus:
+			None: 35
+			Steel: 5
+			Light: 1100
+			Heavy: 1000
+			Concrete: 3
+	Warhead@Cluster: FireCluster
+		Weapon: PodClusterProjectileArtillery
+		RandomClusterCount: -1
+		Dimensions: 3,3
+		Footprint: xxx xXx xxx
+		AirThreshold: 0c0
+	Warhead@Incendiary: TreeDamage
+		Spread: 256
+		Damage: 300
+		Percentage: 75
+	Warhead@Smudge: LeaveSmudge
+		SmudgeType: Crater
+		Chance: 25
+	Warhead@Effect: CreateEffect
+		Explosions: small
+		ImpactSounds: explosion06.ogg
+		ImpactActors: false
+
+PodClusterProjectileArtillery:
+	Inherits: BigSplash
+	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	ReloadDelay: 25
+	Range: 8c0
+	Projectile: Bullet
+		Speed: 250
+		Inaccuracy: 0c512
+		Image: bullet3
+		Shadow: false
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		Spread: 128
+		Damage: 2500
+		Versus:
+			None: 10
+			Steel: 2
+			Light: 100
+			Heavy: 200
+			Concrete: 1
+	Warhead@Incendiary: TreeDamage
+		Spread: 128
+		Damage: 2500
+	Warhead@GroundEffect: CreateEffect
+		Explosions: small
+		ValidTargets: Ground
+		ImpactSounds: explosion06.ogg
 
 BattleShipGun:
 	Inherits: BigSplash
@@ -365,7 +501,7 @@ BattleShipGun:
 		Image: bullet12
 		Shadow: true
 		TrailImage: battleship-trail
-		TrailInterval: 2
+		TrailInterval: 0
 		TrailDelay: 1
 	Warhead@Damage: SpreadDamage
 		Spread: 250

--- a/mods/hv/weapons/ballistics.yaml
+++ b/mods/hv/weapons/ballistics.yaml
@@ -19,10 +19,10 @@
 		Spread: 128
 		Damage: 4000
 		Versus:
-			None: 20
+			None: 80
 			Steel: 75
 			Light: 100
-			Heavy: 130
+			Heavy: 150
 			Wood: 75
 	Warhead@Incendiary: TreeDamage
 		Damage: 4000
@@ -39,12 +39,12 @@ TankCannon:
 CannonSynapol:
 	Inherits: ^Cannon
 	Projectile: Bullet
-		Image: bullet1
+		Image: bullet5
 
 CannonYuruki:
 	Inherits: ^Cannon
 	Projectile: Bullet
-		Image: bullet5
+		Image: bullet1
 
 ^Artillery:
 	Inherits: ^Cannon
@@ -83,11 +83,80 @@ SmallArtillery:
 	MinRange: 4c0
 	TargetActorCenter: true
 	Projectile: Bullet
+		Image: bullet5
 		Inaccuracy: 1c138
 	Warhead@Damage: SpreadDamage
 		Falloff: 100, 55, 20, 5
 		Versus:
 			None: 60
+
+SmallArtilleryLongDistance:
+	Inherits: SmallArtillery
+	MinRange: 6c0
+	Range: 18c0
+	ReloadDelay: 170
+	Projectile: Bullet
+		Image: bullet3
+		Inaccuracy: 3c138
+
+ArtilleryCluster:
+	Inherits: SmallArtillery
+	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	Report: blaster_flyingsaucerinvasion.ogg
+	ReloadDelay: 170
+	Burst: 6
+	BurstDelays: 5
+	MinRange: 4c0
+	Range: 12c0
+	Projectile: Bullet
+		Inaccuracy: 0c256
+		Image: bullet12
+		Shadow: false
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		Spread: 426
+		Damage: 2300
+		Versus:
+			Steel: 30
+			Concrete: 30
+	Warhead@Cluster: FireCluster
+		Weapon: ClusterProjectileArtillery
+		RandomClusterCount: -1
+		Dimensions: 3,3
+		Footprint: xxx xXx xxx
+		AirThreshold: 0c0
+	Warhead@Effect: CreateEffect
+		Explosions: small
+		ImpactSounds: explosion06.ogg
+		ImpactActors: false
+
+ClusterProjectileArtillery:
+	Inherits: BigSplash
+	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	ReloadDelay: 25
+	Range: 8c0
+	Projectile: Bullet
+		Speed: 250
+		Inaccuracy: 0c512
+		Image: bullet3
+		Shadow: false
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		Spread: 128
+		Damage: 2500
+		Versus:
+			None: 50
+			Steel: 25
+			Light: 50
+			Heavy: 50
+			Concrete: 25
+	Warhead@Incendiary: TreeDamage
+		Spread: 128
+		Damage: 2500
+	Warhead@GroundEffect: CreateEffect
+		Explosions: small
+		ValidTargets: Ground
+		ImpactSounds: explosion06.ogg
 
 DoubleBarrelledArtillery:
 	Inherits: ^Artillery
@@ -308,31 +377,30 @@ DoubleCannon:
 MortarGun:
 	Inherits: SmallSplash
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
-	ReloadDelay: 50
+	ReloadDelay: 49
 	Report: grenade-launcher_lemudcrab.ogg
-	Range: 6c0
-	MinRange: 1c0
+	Range: 7c0
 	Projectile: Bullet
 		Image: bullet1
 		Speed: 360
 		Blockable: false
 		LaunchAngle: 80
-		Inaccuracy: 0c512
 		ContrailLength: 10
 		ContrailStartColor: 811000
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
 		ValidTargets: Ground, Water, Tree, Lava, Swamp
-		Spread: 256
+		Spread: 128
 		Damage: 6000
 		Versus:
 			None: 70
-			Steel: 40
-			Light: 25
-			Heavy: 25
+			Steel: 15
+			Light: 15
+			Heavy: 15
 			Wood: 75
+			Concrete: 15
 	Warhead@Incendiary: TreeDamage
-		Spread: 256
+		Spread: 128
 		Damage: 6000
 		Percentage: 75
 	Warhead@Smudge: LeaveSmudge
@@ -345,9 +413,77 @@ MortarGun:
 
 BunkerMortarGun:
 	Inherits: MortarGun
-	Range: 9c0
+	Range: 10c0
 	ReloadDelay: 25
 	MinRange: 0
+
+HeavyMortarGun:
+	Inherits: SmallArtillery
+	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	Report: ccbygrenadelaunch01.ogg
+	Range: 6c0
+	MinRange: 1c0
+	Projectile: Bullet
+		Image: bullet12
+		LaunchAngle: 40
+		Inaccuracy: 512
+		ContrailStartColor: 9bc2eb
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		ValidTargets: Water, Ground, Tree, Lava, Swamp
+		Spread: 256
+		Damage: 300
+		Versus:
+			None: 35
+			Steel: 5
+			Light: 1100
+			Heavy: 1000
+			Concrete: 3
+	Warhead@Cluster: FireCluster
+		Weapon: PodClusterProjectileArtillery
+		RandomClusterCount: -1
+		Dimensions: 3,3
+		Footprint: xxx xXx xxx
+		AirThreshold: 0c0
+	Warhead@Incendiary: TreeDamage
+		Spread: 256
+		Damage: 300
+		Percentage: 75
+	Warhead@Smudge: LeaveSmudge
+		SmudgeType: Crater
+		Chance: 25
+	Warhead@Effect: CreateEffect
+		Explosions: small
+		ImpactSounds: explosion06.ogg
+		ImpactActors: false
+
+PodClusterProjectileArtillery:
+	Inherits: BigSplash
+	ValidTargets: Water, Ground, Tree, Lava, Swamp
+	ReloadDelay: 25
+	Range: 8c0
+	Projectile: Bullet
+		Speed: 250
+		Inaccuracy: 0c512
+		Image: bullet3
+		Shadow: false
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		Spread: 128
+		Damage: 2500
+		Versus:
+			None: 10
+			Steel: 2
+			Light: 100
+			Heavy: 200
+			Concrete: 1
+	Warhead@Incendiary: TreeDamage
+		Spread: 128
+		Damage: 2500
+	Warhead@GroundEffect: CreateEffect
+		Explosions: small
+		ValidTargets: Ground
+		ImpactSounds: explosion06.ogg
 
 BattleShipGun:
 	Inherits: BigSplash
@@ -365,7 +501,7 @@ BattleShipGun:
 		Image: bullet12
 		Shadow: true
 		TrailImage: battleship-trail
-		TrailInterval: 2
+		TrailInterval: 0
 		TrailDelay: 1
 	Warhead@Damage: SpreadDamage
 		Spread: 250

--- a/mods/hv/weapons/bombs.yaml
+++ b/mods/hv/weapons/bombs.yaml
@@ -18,7 +18,7 @@ Bomb:
 	Warhead@Damage: SpreadDamage
 		Spread: 512
 		Falloff: 100, 50, 25, 12, 6, 3, 0
-		Damage: 10000
+		Damage: 15000
 		Versus:
 			None: 90
 			Steel: 75
@@ -28,7 +28,7 @@ Bomb:
 	Warhead@Incendiary: TreeDamage
 		Spread: 512
 		Falloff: 100, 50, 25, 12, 6, 3, 0
-		Damage: 10000
+		Damage: 15000
 		Percentage: 75
 	Warhead@GroundEffect: CreateEffect
 		Explosions: medium

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -266,7 +266,7 @@ RapidPodVoltageArcAir:
 
 LightningBolt:
 	ReloadDelay: 60
-	Range: 9c0
+	Range: 10c0
 	Report: lightningbolt.ogg
 	ValidTargets: Air
 	Projectile: EnergyBolt
@@ -286,8 +286,8 @@ LightningBolt:
 		Versus:
 			None: 30
 			Wood: 90
-			Light: 90
-			Heavy: 300
+			Light: 117
+			Heavy: 390
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
@@ -306,7 +306,7 @@ LightningBolt:
 LightningBoltLight:
 	Inherits: LightningBolt
 	ReloadDelay: 60
-	Range: 8c0
+	Range: 10c0
 	Report: lightningbolt.ogg
 	Warhead@Damage: SpreadDamage
 		Spread: 128
@@ -315,8 +315,8 @@ LightningBoltLight:
 		Versus:
 			None: 30
 			Wood: 90
-			Light: 90
-			Heavy: 300
+			Light: 117
+			Heavy: 390
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Spread: 128

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -57,7 +57,7 @@ ElectronicCountermeasure:
 		AllowSnapping: true
 		Jammable: False
 		Arm: 0
-		RangeLimit: -1
+		RangeLimit: 1024c0
 	Warhead@ECM: GrantExternalCondition
 		Range: 1c0
 		Duration: 90

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -17,21 +17,28 @@ Railgun:
 		DamageTypes: Fire
 		ValidTargets: Ground, Water, Tree, Lava, Swamp
 		Spread: 128
-		Damage: 8000
+		Damage: 6500
 		Versus:
-			None: 200
+			None: 150
 			Steel: 75
 			Light: 125
 			Heavy: 155
 			Wood: 10
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
-		Damage: 8000
+		Damage: 6500
 		Percentage: 10
 	Warhead@GroundEffect: CreateEffect
 		Explosions: small
 		ValidTargets: Ground
 		ImpactSounds: explosion06.ogg
+
+RailgunLongRange:
+	Inherits: Railgun
+	Range: 10c0
+	ReloadDelay: 62
+	Projectile: LaserZap
+		Color: FE03FE
 
 ElectronicCountermeasure:
 	ReloadDelay: 20
@@ -121,7 +128,7 @@ RepairTorch:
 	TargetActorCenter: true
 	Warhead@Repair: TargetDamage
 		DebugOverlayColor: 00FF00
-		Damage: -50
+		Damage: -250
 		ValidTargets: DamagedPod
 		Spread: 1
 	Warhead@Sparks: FireShrapnel
@@ -135,7 +142,7 @@ Plasma:
 	Inherits: BigSplash
 	ValidTargets: Ground, Water, Tree, Lava, Swamp
 	ReloadDelay: 10
-	Range: 8c0
+	Range: 9c0
 	MinRange: 1c0
 	Report: lasercannon_newlocknew.ogg
 	Projectile: Missile
@@ -149,12 +156,12 @@ Plasma:
 		Chance: 25
 		InvalidTargets: Vehicle, Structure
 	Warhead@Damage: SpreadDamage
-		Damage: 1750
+		Damage: 800
 		Versus:
 			None: 43
 			Steel: 85
-			Light: 43
-			Heavy: 43
+			Light: 129
+			Heavy: 129
 			Concrete: 85
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
@@ -165,7 +172,7 @@ Plasma:
 		ValidTargets: Ground, Air, Ship, Tree
 
 VoltageArc:
-	ReloadDelay: 50
+	ReloadDelay: 40
 	Range: 8c0
 	Report: lightningbolt.ogg
 	Projectile: EnergyBolt
@@ -181,7 +188,7 @@ VoltageArc:
 	ValidTargets: Ground, Water, Vehicle, Lava, Swamp
 	Warhead@Damage: SpreadDamage
 		Spread: 128
-		Damage: 8000
+		Damage: 5200
 		Versus:
 			None: 200
 			Steel: 75
@@ -192,7 +199,7 @@ VoltageArc:
 		DamageTypes: Electricity
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
-		Damage: 8000
+		Damage: 5200
 		Percentage: 10
 	Warhead@Sparks: FireShrapnel
 		Weapon: ElectricSpark
@@ -200,11 +207,31 @@ VoltageArc:
 		AffectsParent: true
 		ValidTargets: Ground, Water, Vehicle, Lava, Swamp
 
-PodVoltageArc:
+TankVoltageArc:
+	Inherits: VoltageArc
+	ReloadDelay: 70
+	Range: 7c0
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		ValidTargets: Ground, Water, Tree, Lava, Swamp
+		Spread: 128
+		Damage: 4200
+		Versus:
+			None: 80
+			Steel: 75
+			Light: 100
+			Heavy: 155
+			Wood: 75
+	Warhead@Incendiary: TreeDamage
+		Damage: 4000
+		Spread: 128
+		Percentage: 75
+
+PodVoltageArcGround:
 	Inherits: VoltageArc
 	Range: 5c512
 	Report: lighting_gun_freqman.ogg
-	ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
+	ValidTargets: Ground, Water, Tree, Lava, Swamp
 	ReloadDelay: 60
 	Projectile: EnergyBolt
 		Radius: 2
@@ -218,13 +245,22 @@ PodVoltageArc:
 			Heavy: 110
 			Concrete: 50
 		ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
-	Warhead@Incendiary: TreeDamage
-		Spread: 128
-		Damage: 2500
-		ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
 
-RapidPodVoltageArc:
-	Inherits: PodVoltageArc
+PodVoltageArcAir:
+	Inherits: PodVoltageArcGround
+	ValidTargets: Air
+	Warhead@Damage: SpreadDamage
+		Versus:
+			Steel: 0
+			Concrete: 0
+
+RapidPodVoltageArcGround:
+	Inherits: PodVoltageArcGround
+	Range: 8c0
+	ReloadDelay: 30
+
+RapidPodVoltageArcAir:
+	Inherits: PodVoltageArcAir
 	Range: 8c0
 	ReloadDelay: 30
 
@@ -526,7 +562,7 @@ MothershipLaser:
 		ValidTargets: Ground, Air, Ship, Tree
 
 ^BrokerWireTransfer:
-	Range: 12c0
+	Range: 5c0
 	ValidTargets: Defraudable
 	Report: coinflick.ogg
 	Projectile: ArcLaserZap
@@ -551,7 +587,7 @@ BrokerWireTransfer:
 	ReloadDelay: 5
 	Report: klink.ogg
 	Warhead@Leech: RobMoney
-		Amount: 500
+		Amount: 100
 		RobbedTextNotification: robbed-notification
 		RobTextNotification: rob-notification
 
@@ -573,9 +609,8 @@ PlasmaMachineGun:
 		DamageTypes: Fire
 		ValidTargets: Air
 		Spread: 256
-		Damage: 2500
+		Damage: 725
 		Versus:
-			Steel: 50
 			Light: 50
 			Heavy: 50
 	Warhead@GroundEffect: CreateEffect

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -19,7 +19,7 @@ Railgun:
 		Spread: 128
 		Damage: 6500
 		Versus:
-			None: 150
+			None: 155
 			Steel: 75
 			Light: 125
 			Heavy: 155

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -17,21 +17,28 @@ Railgun:
 		DamageTypes: Fire
 		ValidTargets: Ground, Water, Tree, Lava, Swamp
 		Spread: 128
-		Damage: 8000
+		Damage: 6500
 		Versus:
-			None: 200
+			None: 155
 			Steel: 75
 			Light: 125
 			Heavy: 155
 			Wood: 10
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
-		Damage: 8000
+		Damage: 6500
 		Percentage: 10
 	Warhead@GroundEffect: CreateEffect
 		Explosions: small
 		ValidTargets: Ground
 		ImpactSounds: explosion06.ogg
+
+RailgunLongRange:
+	Inherits: Railgun
+	Range: 10c0
+	ReloadDelay: 62
+	Projectile: LaserZap
+		Color: FE03FE
 
 ElectronicCountermeasure:
 	ReloadDelay: 20
@@ -121,7 +128,7 @@ RepairTorch:
 	TargetActorCenter: true
 	Warhead@Repair: TargetDamage
 		DebugOverlayColor: 00FF00
-		Damage: -50
+		Damage: -250
 		ValidTargets: DamagedPod
 		Spread: 1
 	Warhead@Sparks: FireShrapnel
@@ -135,7 +142,7 @@ Plasma:
 	Inherits: BigSplash
 	ValidTargets: Ground, Water, Tree, Lava, Swamp
 	ReloadDelay: 10
-	Range: 8c0
+	Range: 9c0
 	MinRange: 1c0
 	Report: lasercannon_newlocknew.ogg
 	Projectile: Missile
@@ -149,12 +156,12 @@ Plasma:
 		Chance: 25
 		InvalidTargets: Vehicle, Structure
 	Warhead@Damage: SpreadDamage
-		Damage: 1750
+		Damage: 800
 		Versus:
 			None: 43
 			Steel: 85
-			Light: 43
-			Heavy: 43
+			Light: 129
+			Heavy: 129
 			Concrete: 85
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
@@ -165,7 +172,7 @@ Plasma:
 		ValidTargets: Ground, Air, Ship, Tree
 
 VoltageArc:
-	ReloadDelay: 50
+	ReloadDelay: 40
 	Range: 8c0
 	Report: lightningbolt.ogg
 	Projectile: EnergyBolt
@@ -181,7 +188,7 @@ VoltageArc:
 	ValidTargets: Ground, Water, Vehicle, Lava, Swamp
 	Warhead@Damage: SpreadDamage
 		Spread: 128
-		Damage: 8000
+		Damage: 5200
 		Versus:
 			None: 200
 			Steel: 75
@@ -192,7 +199,7 @@ VoltageArc:
 		DamageTypes: Electricity
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
-		Damage: 8000
+		Damage: 5200
 		Percentage: 10
 	Warhead@Sparks: FireShrapnel
 		Weapon: ElectricSpark
@@ -200,11 +207,31 @@ VoltageArc:
 		AffectsParent: true
 		ValidTargets: Ground, Water, Vehicle, Lava, Swamp
 
-PodVoltageArc:
+TankVoltageArc:
+	Inherits: VoltageArc
+	ReloadDelay: 70
+	Range: 7c0
+	Warhead@Damage: SpreadDamage
+		DamageTypes: Fire
+		ValidTargets: Ground, Water, Tree, Lava, Swamp
+		Spread: 128
+		Damage: 4200
+		Versus:
+			None: 80
+			Steel: 75
+			Light: 100
+			Heavy: 155
+			Wood: 75
+	Warhead@Incendiary: TreeDamage
+		Damage: 4000
+		Spread: 128
+		Percentage: 75
+
+PodVoltageArcGround:
 	Inherits: VoltageArc
 	Range: 5c512
 	Report: lighting_gun_freqman.ogg
-	ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
+	ValidTargets: Ground, Water, Tree, Lava, Swamp
 	ReloadDelay: 60
 	Projectile: EnergyBolt
 		Radius: 2
@@ -218,13 +245,22 @@ PodVoltageArc:
 			Heavy: 110
 			Concrete: 50
 		ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
-	Warhead@Incendiary: TreeDamage
-		Spread: 128
-		Damage: 2500
-		ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
 
-RapidPodVoltageArc:
-	Inherits: PodVoltageArc
+PodVoltageArcAir:
+	Inherits: PodVoltageArcGround
+	ValidTargets: Air
+	Warhead@Damage: SpreadDamage
+		Versus:
+			Steel: 0
+			Concrete: 0
+
+RapidPodVoltageArcGround:
+	Inherits: PodVoltageArcGround
+	Range: 8c0
+	ReloadDelay: 30
+
+RapidPodVoltageArcAir:
+	Inherits: PodVoltageArcAir
 	Range: 8c0
 	ReloadDelay: 30
 
@@ -526,7 +562,7 @@ MothershipLaser:
 		ValidTargets: Ground, Air, Ship, Tree
 
 ^BrokerWireTransfer:
-	Range: 12c0
+	Range: 5c0
 	ValidTargets: Defraudable
 	Report: coinflick.ogg
 	Projectile: ArcLaserZap
@@ -551,7 +587,7 @@ BrokerWireTransfer:
 	ReloadDelay: 5
 	Report: klink.ogg
 	Warhead@Leech: RobMoney
-		Amount: 500
+		Amount: 100
 		RobbedTextNotification: robbed-notification
 		RobTextNotification: rob-notification
 
@@ -573,9 +609,8 @@ PlasmaMachineGun:
 		DamageTypes: Fire
 		ValidTargets: Air
 		Spread: 256
-		Damage: 2500
+		Damage: 725
 		Versus:
-			Steel: 50
 			Light: 50
 			Heavy: 50
 	Warhead@GroundEffect: CreateEffect

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -57,7 +57,7 @@ ElectronicCountermeasure:
 		AllowSnapping: true
 		Jammable: False
 		Arm: 0
-		RangeLimit: -1
+		RangeLimit: 128c0
 	Warhead@ECM: GrantExternalCondition
 		Range: 1c0
 		Duration: 90

--- a/mods/hv/weapons/explosions.yaml
+++ b/mods/hv/weapons/explosions.yaml
@@ -105,28 +105,28 @@ ExplosiveCharge:
 	Warhead@Damage: TargetDamage
 		DamageTypes: Fire
 		Spread: 512
-		Damage: 10000
+		Damage: 7500
 		Versus:
-			None: 150
-			Steel: 320
+			None: 300
+			Steel: 425
 			Light: 350
-			Heavy: 350
+			Heavy: 700
 			Wood: 350
-			Concrete: 350
+			Concrete: 700
 
 BlasterExplosion:
 	ValidTargets: Ground, Structure
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
-		Spread: 512
-		Damage: 7500
+		Spread: 256
+		Damage: 2500
 		Versus:
-			None: 125
-			Steel: 50
-			Light: 50
-			Heavy: 50
-			Wood: 100
-			Concrete: 50
+			None: 300
+			Steel: 425
+			Light: 350
+			Heavy: 700
+			Wood: 350
+			Concrete: 700
 	Warhead@Effect: CreateEffect
 		Image: explosion
 		Explosions: medium

--- a/mods/hv/weapons/explosions.yaml
+++ b/mods/hv/weapons/explosions.yaml
@@ -7,10 +7,6 @@ BuildingExplode:
 
 ^Explosion:
 	ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
-	Warhead@Damage: SpreadDamage
-		Spread: 426
-	Warhead@Incendiary: TreeDamage
-		Spread: 426
 	Warhead@Effect: CreateEffect
 		Explosions: small_2
 		ValidTargets: Ground, Air, Water, Lava, Swamp
@@ -36,8 +32,10 @@ UnitExplodeLargeDamaging:
 	Warhead@Effect: CreateEffect
 		Explosions: large
 	Warhead@Damage: SpreadDamage
+		Spread: 426
 		Damage: 8000
 	Warhead@Incendiary: TreeDamage
+		Spread: 426
 		Damage: 8000
 
 UnitExplodeHuge:

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -32,6 +32,16 @@
 		ContrailStartWidth: 18
 		ContrailZOffset: 3000
 
+^BlueSniperTracers:
+	Inherits: ^BlueTracers
+	Projectile: InstantHitWithTracers
+		TracerAmount: 2
+		TracerSpeed: 5000
+		TracerSpawnInterval: 0
+		TracerInaccuracy: 0
+		ContrailLength: 4
+		ContrailStartWidth: 48
+
 LightMachineGun:
 	Inherits: SmallSplash
 	Inherits: Ricochet
@@ -108,10 +118,10 @@ BuggyChainGun:
 		Damage: 1100
 		Versus:
 			None: 270
-			Steel: 10
+			Steel: 8
 			Light: 30
 			Heavy: 10
-			Concrete: 5
+			Concrete: 4
 
 BikeChainGun:
 	Inherits: BuggyChainGun
@@ -120,13 +130,13 @@ BikeChainGun:
 	Range: 7c0
 	Warhead@Damage: SpreadDamage
 		Spread: 24
-		Damage: 1000
+		Damage: 1350
 		Versus:
 			None: 270
-			Steel: 10
+			Steel: 8
 			Light: 30
 			Heavy: 10
-			Concrete: 5
+			Concrete: 4
 
 HelicopterChainGunGround:
 	Inherits: ^AircraftChainGun
@@ -140,51 +150,41 @@ HelicopterChainGunGround:
 		Versus:
 			None: 540
 			Steel: 60
-			Light: 295
+			Light: 290
 			Heavy: 40
 			Concrete: 20
-	Warhead@Incendiary: TreeDamage
-		Spread: 64
-		Damage: 250
 
 HelicopterChainGunAir:
 	Inherits: HelicopterChainGunGround
 	ValidTargets: Air
 	Warhead@Damage: SpreadDamage
-		Damage: 250
 		Versus:
-			Light: 167
-			Heavy: 115
+			Steel: 0
+			Concrete: 0
 
 AircraftChainGunGround:
 	Inherits: ^AircraftChainGun
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
-	ReloadDelay: 3
+	ReloadDelay: 6
 	Range: 6c0
 	MinRange: 1c0
 	Burst: 16
-	Projectile: InstantHit
-		Blockable: false
 	Warhead@Damage: SpreadDamage
 		Damage: 375
 		Versus:
-			None: 800
-			Steel: 108
-			Light: 365
-			Heavy: 65
-			Concrete: 63
-	Warhead@Incendiary: TreeDamage
-		Spread: 64
-		Damage: 375
+			None: 270
+			Steel: 30
+			Light: 145
+			Heavy: 20
+			Concrete: 10
 
 AircraftChainGunAir:
 	Inherits: AircraftChainGunGround
 	ValidTargets: Air
 	Warhead@Damage: SpreadDamage
-		Damage: 375
 		Versus:
-			Light: 207
-			Heavy: 185
+			Steel: 0
+			Concrete: 0
 
 ShellCasing:
 	Inherits: SmallSplash
@@ -205,10 +205,13 @@ ShellCasing:
 
 SniperRifle:
 	Inherits: LightMachineGun
+	Inherits: ^BlueSniperTracers
 	Report: twisterman_silenced-gun-1.ogg
-	Projectile: InstantHit
+	Projectile: InstantHitWithTracers
+		Inaccuracy: 0
 	Warhead@Damage: SpreadDamage
 		Spread: 24
+		Damage: 750
 		Versus:
 			None: 1500
 			Steel: 40
@@ -216,6 +219,7 @@ SniperRifle:
 			Heavy: 25
 			Concrete: 15
 	Warhead@Incendiary: TreeDamage
+		Damage: 750
 		Spread: 24
 	ReloadDelay: 50
 	Range: 10c0
@@ -276,10 +280,10 @@ BoatMachineGunAir:
 Flamethrower:
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
 	StartBurstReport: flame_newlocknew.ogg
-	ReloadDelay: 50
-	Burst: 6
-	BurstDelays: 1
-	Range: 3c0
+	ReloadDelay: 2
+	Burst: 2
+	BurstDelays: 0
+	Range: 4c0
 	Projectile: Bullet
 		Image: bullet17
 		TrailImage: bullet17-trace
@@ -293,15 +297,16 @@ Flamethrower:
 		DamageTypes: Fire
 		ValidTargets: Ground, Water, Tree, Lava, Swamp
 		Spread: 128
-		Damage: 2000
+		Damage: 200
 		Versus:
 			None: 90
 			Steel: 45
-			Light: 8
-			Heavy: 5
+			Light: 45
+			Heavy: 45
 			Wood: 100
+			Concrete: 45
 	Warhead@Incendiary: TreeDamage
-		Damage: 2000
+		Damage: 200
 		Spread: 128
 		Percentage: 75
 	Warhead@FireEffect: CreateEffect
@@ -312,29 +317,8 @@ Flamethrower:
 
 BunkerFlamethrower:
 	Inherits: Flamethrower
-	ReloadDelay: 25
-	Range: 5c0
-
-HeavyMachineGun:
-	Inherits: LightMachineGun
-	ValidTargets: Water, Air, Ground, Tree, Lava, Swamp
-	Report: machine_gun_pgi.ogg
-	ReloadDelay: 20
+	ReloadDelay: 1
 	Range: 6c0
-	Burst: 4
-	BurstDelays: 2
-	Projectile: InstantHitWithTracers
-		Blockable: false
-	Warhead@Damage: SpreadDamage
-		ValidTargets: Water, Air, Ground, Tree, Lava, Swamp
-		Spread: 24
-		Damage: 300
-		Versus:
-			None: 300
-			Steel: 25
-			Light: 55
-			Heavy: 20
-			Concrete: 5
 
 DronePulseGun:
 	Inherits: SmallSplash

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -260,7 +260,7 @@ BoatMachineGunAir:
 	Report: boatgun_johandeecke.ogg
 	BurstDelays: 5
 	ReloadDelay: 20
-	Range: 9c0
+	Range: 10c0
 	Burst: 4
 	Projectile: InstantHitWithTracers
 		Inaccuracy: 0c512

--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -32,6 +32,16 @@
 		ContrailStartWidth: 18
 		ContrailZOffset: 3000
 
+^BlueSniperTracers:
+	Inherits: ^BlueTracers
+	Projectile: InstantHitWithTracers
+		TracerAmount: 1
+		TracerSpeed: 5000
+		TracerSpawnInterval: 0
+		TracerInaccuracy: 0
+		ContrailLength: 4
+		ContrailStartWidth: 48
+
 LightMachineGun:
 	Inherits: SmallSplash
 	Inherits: Ricochet
@@ -108,10 +118,10 @@ BuggyChainGun:
 		Damage: 1100
 		Versus:
 			None: 270
-			Steel: 10
+			Steel: 8
 			Light: 30
 			Heavy: 10
-			Concrete: 5
+			Concrete: 4
 
 BikeChainGun:
 	Inherits: BuggyChainGun
@@ -120,13 +130,13 @@ BikeChainGun:
 	Range: 7c0
 	Warhead@Damage: SpreadDamage
 		Spread: 24
-		Damage: 1000
+		Damage: 1350
 		Versus:
 			None: 270
-			Steel: 10
+			Steel: 8
 			Light: 30
 			Heavy: 10
-			Concrete: 5
+			Concrete: 4
 
 HelicopterChainGunGround:
 	Inherits: ^AircraftChainGun
@@ -140,51 +150,41 @@ HelicopterChainGunGround:
 		Versus:
 			None: 540
 			Steel: 60
-			Light: 295
+			Light: 290
 			Heavy: 40
 			Concrete: 20
-	Warhead@Incendiary: TreeDamage
-		Spread: 64
-		Damage: 250
 
 HelicopterChainGunAir:
 	Inherits: HelicopterChainGunGround
 	ValidTargets: Air
 	Warhead@Damage: SpreadDamage
-		Damage: 250
 		Versus:
-			Light: 167
-			Heavy: 115
+			Steel: 0
+			Concrete: 0
 
 AircraftChainGunGround:
 	Inherits: ^AircraftChainGun
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
-	ReloadDelay: 3
+	ReloadDelay: 6
 	Range: 6c0
 	MinRange: 1c0
 	Burst: 16
-	Projectile: InstantHit
-		Blockable: false
 	Warhead@Damage: SpreadDamage
 		Damage: 375
 		Versus:
-			None: 800
-			Steel: 108
-			Light: 365
-			Heavy: 65
-			Concrete: 63
-	Warhead@Incendiary: TreeDamage
-		Spread: 64
-		Damage: 375
+			None: 270
+			Steel: 30
+			Light: 145
+			Heavy: 20
+			Concrete: 10
 
 AircraftChainGunAir:
 	Inherits: AircraftChainGunGround
 	ValidTargets: Air
 	Warhead@Damage: SpreadDamage
-		Damage: 375
 		Versus:
-			Light: 207
-			Heavy: 185
+			Steel: 0
+			Concrete: 0
 
 ShellCasing:
 	Inherits: SmallSplash
@@ -205,10 +205,13 @@ ShellCasing:
 
 SniperRifle:
 	Inherits: LightMachineGun
+	Inherits: ^BlueSniperTracers
 	Report: twisterman_silenced-gun-1.ogg
-	Projectile: InstantHit
+	Projectile: InstantHitWithTracers
+		Inaccuracy: 0
 	Warhead@Damage: SpreadDamage
 		Spread: 24
+		Damage: 750
 		Versus:
 			None: 1500
 			Steel: 40
@@ -216,6 +219,7 @@ SniperRifle:
 			Heavy: 25
 			Concrete: 15
 	Warhead@Incendiary: TreeDamage
+		Damage: 750
 		Spread: 24
 	ReloadDelay: 50
 	Range: 10c0
@@ -276,10 +280,10 @@ BoatMachineGunAir:
 Flamethrower:
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
 	StartBurstReport: flame_newlocknew.ogg
-	ReloadDelay: 50
-	Burst: 6
-	BurstDelays: 1
-	Range: 3c0
+	ReloadDelay: 2
+	Burst: 2
+	BurstDelays: 0
+	Range: 4c0
 	Projectile: Bullet
 		Image: bullet17
 		TrailImage: bullet17-trace
@@ -293,15 +297,16 @@ Flamethrower:
 		DamageTypes: Fire
 		ValidTargets: Ground, Water, Tree, Lava, Swamp
 		Spread: 128
-		Damage: 2000
+		Damage: 200
 		Versus:
 			None: 90
 			Steel: 45
-			Light: 8
-			Heavy: 5
+			Light: 45
+			Heavy: 45
 			Wood: 100
+			Concrete: 45
 	Warhead@Incendiary: TreeDamage
-		Damage: 2000
+		Damage: 200
 		Spread: 128
 		Percentage: 75
 	Warhead@FireEffect: CreateEffect
@@ -312,29 +317,8 @@ Flamethrower:
 
 BunkerFlamethrower:
 	Inherits: Flamethrower
-	ReloadDelay: 25
-	Range: 5c0
-
-HeavyMachineGun:
-	Inherits: LightMachineGun
-	ValidTargets: Water, Air, Ground, Tree, Lava, Swamp
-	Report: machine_gun_pgi.ogg
-	ReloadDelay: 20
+	ReloadDelay: 1
 	Range: 6c0
-	Burst: 4
-	BurstDelays: 2
-	Projectile: InstantHitWithTracers
-		Blockable: false
-	Warhead@Damage: SpreadDamage
-		ValidTargets: Water, Air, Ground, Tree, Lava, Swamp
-		Spread: 24
-		Damage: 300
-		Versus:
-			None: 300
-			Steel: 25
-			Light: 55
-			Heavy: 20
-			Concrete: 5
 
 DronePulseGun:
 	Inherits: SmallSplash

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -209,7 +209,7 @@ BoatMissileAntiAir:
 	Inherits: ^AntiAirMissile
 	ReloadDelay: 50
 	Report: rocketlaunch03.ogg
-	Range: 9c0
+	Range: 10c0
 	ValidTargets: Air
 	Burst: 3
 	BurstDelays: 8
@@ -255,7 +255,7 @@ StealthTankMissile:
 Patriot:
 	Inherits: ^AntiAirMissile
 	ReloadDelay: 45
-	Range: 8c0
+	Range: 10c0
 	Report: rocketlaunch03.ogg
 	ValidTargets: Air
 	Projectile: Missile
@@ -266,8 +266,8 @@ Patriot:
 		Versus:
 			None: 30
 			Wood: 90
-			Light: 90
-			Heavy: 300
+			Light: 117
+			Heavy: 390
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
@@ -281,7 +281,7 @@ Patriot:
 TowerMissile:
 	Inherits: ^AntiAirMissile
 	ReloadDelay: 45
-	Range: 9c0
+	Range: 10c0
 	Report: rocketlaunch03.ogg
 	ValidTargets: Air
 	Warhead@Damage: SpreadDamage
@@ -291,8 +291,8 @@ TowerMissile:
 		Versus:
 			None: 30
 			Wood: 90
-			Light: 90
-			Heavy: 300
+			Light: 117
+			Heavy: 390
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Spread: 128

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -80,20 +80,20 @@ MissileTankRocket:
 		Speed: 256
 		CloseEnough: 256
 	Warhead@Damage: SpreadDamage
-		Damage: 6000
+		Damage: 2750
 		Versus:
-			None: 8
-			Steel: 75
+			None: 40
+			Steel: 50
 			Light: 75
-			Heavy: 75
-			Concrete: 75
+			Heavy: 95
+			Concrete: 50
 	Warhead@Incendiary: TreeDamage
-		Damage: 6000
+		Damage: 2750
 
-LightPodRocket:
+LightPodRocketGround:
 	Inherits: SmallSplash
 	Inherits: ^AntiGroundMissile
-	ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
+	ValidTargets: Ground, Water, Tree, Lava, Swamp
 	Range: 5c512
 	ReloadDelay: 45
 	Projectile: Missile
@@ -110,17 +110,55 @@ LightPodRocket:
 			Heavy: 110
 			Concrete: 50
 
-RapidPodRocket:
-	Inherits: LightPodRocket
+LightPodRocketAir:
+	Inherits: LightPodRocketGround
+	ValidTargets: Air
+	Warhead@Damage: SpreadDamage
+		Versus:
+			Steel: 0
+			Concrete: 0
+
+RapidPodRocketGround:
+	Inherits: LightPodRocketGround
 	ReloadDelay: 23
 	Range: 8c0
+
+RapidPodRocketAir:
+	Inherits: LightPodRocketAir
+	ReloadDelay: 23
+	Range: 8c0
+
+PodDrunkMissiles:
+	Inherits: LightPodRocketGround
+	ValidTargets: Ground, Water, Tree, Lava, Swamp
+	ReloadDelay: 60
+	Range: 7c0
+	Burst: 4
+	BurstDelays: 2
+	MinRange: 1c0
+	Projectile: Bullet
+		Inaccuracy: 1024
+		Speed: 300
+		Image: bullet6
+		TrailImage: small_smoke
+		TrailInterval: 3
+	Warhead@Damage: SpreadDamage
+		ValidTargets: Ground, Water, Tree, Lava, Swamp
+		Spread: 128
+		Damage: 1500
+		Versus:
+			None: 800
+			Light: 2
+			Heavy: 7
+			Steel: 3
+			Concrete: 3
 
 ShipMissile:
 	Inherits: ^AntiGroundMissile
 	Inherits: BigSplash
 	ValidTargets: Ground, Water, Tree, Lava, Swamp
 	ReloadDelay: 25
-	Range: 8c0
+	Range: 9c0
 	MinRange: 1c0
 	Projectile: Missile
 		Speed: 256
@@ -128,30 +166,31 @@ ShipMissile:
 		Image: bullet18
 		TrailImage: smoke_blue
 	Warhead@Damage: SpreadDamage
-		Damage: 2000
+		Damage: 2200
 		Versus:
 			None: 45
 			Steel: 90
-			Light: 45
-			Heavy: 45
+			Light: 135
+			Heavy: 135
 			Concrete: 90
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
-		Damage: 2000
+		Damage: 2200
 
 BoatMissileAntiGround:
 	Inherits: SmallSplash
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
-	Report: boatgun_johandeecke.ogg
+	Report: lasercannon_newlocknew.ogg
 	ReloadDelay: 58
 	Range: 6c0
 	Projectile: Bullet
-		Image: bullet6
-		Speed: 1000
+		Image: bullet8
+		Speed: 1750
 		Blockable: false
 		ContrailLength: 4
 		ContrailStartWidth: 0c32
-		ContrailStartColor: F29100
+		ContrailStartColor: FFFFFF
+		ContrailDelay: 0
 	Warhead@Damage: SpreadDamage
 		Spread: 126
 		Damage: 1000
@@ -205,11 +244,11 @@ StealthTankMissile:
 	Warhead@Damage: SpreadDamage
 		Damage: 7250
 		Versus:
-			None: 10
-			Steel: 100
+			None: 105
+			Steel: 70
 			Light: 100
-			Heavy: 100
-			Concrete: 100
+			Heavy: 105
+			Concrete: 85
 	Warhead@Incendiary: TreeDamage
 		Damage: 7250
 
@@ -295,8 +334,8 @@ Torpedo:
 	Range: 6c0
 	Report: torpedo_murraysortz.ogg
 	Warhead@Damage: SpreadDamage
-		Spread: 256
-		Damage: 10000
+		Spread: 128
+		Damage: 9000
 		Versus:
 			None: 100
 			Steel: 50
@@ -320,7 +359,7 @@ BoatTorpedo:
 	Burst: 2
 	BurstDelays: 8
 	Warhead@Damage: SpreadDamage
-		Damage: 5000
+		Damage: 4500
 
 DiscThrower:
 	Inherits: ^AntiAirMissile
@@ -334,13 +373,12 @@ DiscThrower:
 		-TrailImage:
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
-		Spread: 512
+		Spread: 288
 		Damage: 8000
 		ValidTargets: Air
 		Versus:
-			Steel: 74
-			Light: 34
-			Heavy: 100
+			Light: 35
+			Heavy: 35
 	Warhead@Effect: CreateEffect
 		Explosions: small
 		ImpactSounds: explosion06.ogg

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -15,7 +15,7 @@
 		CruiseAltitude: 128
 		AllowSnapping: true
 		Arm: 0
-		RangeLimit: -1
+		RangeLimit: 1024c0
 		Image: bullet6
 		TrailImage: smoke
 	Warhead@Smudge: LeaveSmudge

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -244,7 +244,7 @@ StealthTankMissile:
 	Warhead@Damage: SpreadDamage
 		Damage: 7250
 		Versus:
-			None: 105
+			None: 138
 			Steel: 70
 			Light: 100
 			Heavy: 105

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -239,15 +239,16 @@ StealthTankMissile:
 	Projectile: Missile
 		Speed: 213
 		CloseEnough: 213
+		Jammable: false
 		Image: bullet14
 		TrailImage: stealthtank-trail
 	Warhead@Damage: SpreadDamage
 		Damage: 7250
 		Versus:
 			None: 138
-			Steel: 70
+			Steel: 76
 			Light: 100
-			Heavy: 105
+			Heavy: 115
 			Concrete: 85
 	Warhead@Incendiary: TreeDamage
 		Damage: 7250

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -209,7 +209,7 @@ BoatMissileAntiAir:
 	Inherits: ^AntiAirMissile
 	ReloadDelay: 50
 	Report: rocketlaunch03.ogg
-	Range: 9c0
+	Range: 10c0
 	ValidTargets: Air
 	Burst: 3
 	BurstDelays: 8
@@ -256,7 +256,7 @@ StealthTankMissile:
 Patriot:
 	Inherits: ^AntiAirMissile
 	ReloadDelay: 45
-	Range: 8c0
+	Range: 10c0
 	Report: rocketlaunch03.ogg
 	ValidTargets: Air
 	Projectile: Missile
@@ -267,8 +267,8 @@ Patriot:
 		Versus:
 			None: 30
 			Wood: 90
-			Light: 90
-			Heavy: 300
+			Light: 117
+			Heavy: 390
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
@@ -282,7 +282,7 @@ Patriot:
 TowerMissile:
 	Inherits: ^AntiAirMissile
 	ReloadDelay: 45
-	Range: 9c0
+	Range: 10c0
 	Report: rocketlaunch03.ogg
 	ValidTargets: Air
 	Warhead@Damage: SpreadDamage
@@ -292,8 +292,8 @@ TowerMissile:
 		Versus:
 			None: 30
 			Wood: 90
-			Light: 90
-			Heavy: 300
+			Light: 117
+			Heavy: 390
 			Concrete: 100
 	Warhead@Incendiary: TreeDamage
 		Spread: 128

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -15,7 +15,7 @@
 		CruiseAltitude: 128
 		AllowSnapping: true
 		Arm: 0
-		RangeLimit: -1
+		RangeLimit: 128c0
 		Image: bullet6
 		TrailImage: smoke
 	Warhead@Smudge: LeaveSmudge

--- a/mods/hv/weapons/missiles.yaml
+++ b/mods/hv/weapons/missiles.yaml
@@ -80,20 +80,20 @@ MissileTankRocket:
 		Speed: 256
 		CloseEnough: 256
 	Warhead@Damage: SpreadDamage
-		Damage: 6000
+		Damage: 2750
 		Versus:
-			None: 8
-			Steel: 75
+			None: 40
+			Steel: 50
 			Light: 75
-			Heavy: 75
-			Concrete: 75
+			Heavy: 95
+			Concrete: 50
 	Warhead@Incendiary: TreeDamage
-		Damage: 6000
+		Damage: 2750
 
-LightPodRocket:
+LightPodRocketGround:
 	Inherits: SmallSplash
 	Inherits: ^AntiGroundMissile
-	ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
+	ValidTargets: Ground, Water, Tree, Lava, Swamp
 	Range: 5c512
 	ReloadDelay: 45
 	Projectile: Missile
@@ -110,17 +110,55 @@ LightPodRocket:
 			Heavy: 110
 			Concrete: 50
 
-RapidPodRocket:
-	Inherits: LightPodRocket
+LightPodRocketAir:
+	Inherits: LightPodRocketGround
+	ValidTargets: Air
+	Warhead@Damage: SpreadDamage
+		Versus:
+			Steel: 0
+			Concrete: 0
+
+RapidPodRocketGround:
+	Inherits: LightPodRocketGround
 	ReloadDelay: 23
 	Range: 8c0
+
+RapidPodRocketAir:
+	Inherits: LightPodRocketAir
+	ReloadDelay: 23
+	Range: 8c0
+
+PodDrunkMissiles:
+	Inherits: LightPodRocketGround
+	ValidTargets: Ground, Water, Tree, Lava, Swamp
+	ReloadDelay: 60
+	Range: 7c0
+	Burst: 4
+	BurstDelays: 2
+	MinRange: 1c0
+	Projectile: Bullet
+		Inaccuracy: 1024
+		Speed: 300
+		Image: bullet6
+		TrailImage: small_smoke
+		TrailInterval: 3
+	Warhead@Damage: SpreadDamage
+		ValidTargets: Ground, Water, Tree, Lava, Swamp
+		Spread: 128
+		Damage: 1500
+		Versus:
+			None: 800
+			Light: 2
+			Heavy: 7
+			Steel: 3
+			Concrete: 3
 
 ShipMissile:
 	Inherits: ^AntiGroundMissile
 	Inherits: BigSplash
 	ValidTargets: Ground, Water, Tree, Lava, Swamp
 	ReloadDelay: 25
-	Range: 8c0
+	Range: 9c0
 	MinRange: 1c0
 	Projectile: Missile
 		Speed: 256
@@ -128,30 +166,31 @@ ShipMissile:
 		Image: bullet18
 		TrailImage: smoke_blue
 	Warhead@Damage: SpreadDamage
-		Damage: 2000
+		Damage: 2200
 		Versus:
 			None: 45
 			Steel: 90
-			Light: 45
-			Heavy: 45
+			Light: 135
+			Heavy: 135
 			Concrete: 90
 	Warhead@Incendiary: TreeDamage
 		Spread: 128
-		Damage: 2000
+		Damage: 2200
 
 BoatMissileAntiGround:
 	Inherits: SmallSplash
 	ValidTargets: Water, Ground, Tree, Lava, Swamp
-	Report: boatgun_johandeecke.ogg
+	Report: lasercannon_newlocknew.ogg
 	ReloadDelay: 58
 	Range: 6c0
 	Projectile: Bullet
-		Image: bullet6
-		Speed: 1000
+		Image: bullet8
+		Speed: 1750
 		Blockable: false
 		ContrailLength: 4
 		ContrailStartWidth: 0c32
-		ContrailStartColor: F29100
+		ContrailStartColor: FFFFFF
+		ContrailDelay: 0
 	Warhead@Damage: SpreadDamage
 		Spread: 126
 		Damage: 1000
@@ -200,16 +239,17 @@ StealthTankMissile:
 	Projectile: Missile
 		Speed: 213
 		CloseEnough: 213
+		Jammable: false
 		Image: bullet14
 		TrailImage: stealthtank-trail
 	Warhead@Damage: SpreadDamage
 		Damage: 7250
 		Versus:
-			None: 10
-			Steel: 100
+			None: 138
+			Steel: 76
 			Light: 100
-			Heavy: 100
-			Concrete: 100
+			Heavy: 115
+			Concrete: 85
 	Warhead@Incendiary: TreeDamage
 		Damage: 7250
 
@@ -295,8 +335,8 @@ Torpedo:
 	Range: 6c0
 	Report: torpedo_murraysortz.ogg
 	Warhead@Damage: SpreadDamage
-		Spread: 256
-		Damage: 10000
+		Spread: 128
+		Damage: 9000
 		Versus:
 			None: 100
 			Steel: 50
@@ -320,7 +360,7 @@ BoatTorpedo:
 	Burst: 2
 	BurstDelays: 8
 	Warhead@Damage: SpreadDamage
-		Damage: 5000
+		Damage: 4500
 
 DiscThrower:
 	Inherits: ^AntiAirMissile
@@ -334,13 +374,12 @@ DiscThrower:
 		-TrailImage:
 	Warhead@Damage: SpreadDamage
 		DamageTypes: Fire
-		Spread: 512
+		Spread: 288
 		Damage: 8000
 		ValidTargets: Air
 		Versus:
-			Steel: 74
-			Light: 34
-			Heavy: 100
+			Light: 35
+			Heavy: 35
 	Warhead@Effect: CreateEffect
 		Explosions: small
 		ImpactSounds: explosion06.ogg


### PR DESCRIPTION
## Overall Objective

Make each faction have a distinct gameplay identity. Yuruki is supposed to be focused on stealth and specialized tactics and weaponry, and Synapol should be focused on raw firepower and flexibility in combat.

## Phase 1 Objective

For the Phase 1, the plan is to change unit availability between the factions and do some QoL and balance work.

## Details

<details><summary>QoL changes</summary>

#### From Pull Requests:

- #1305
- #1306
- #1307
- #1331
- #1341
- #1359
- #1360
- #1361
- #1369
- #1370
- #1378
- #1379
- #1380
- #1383
- #1384
- #1392
- #1402
- #1405
- #1429
- #1430 
- #1431 
- #1432 
- #1433 
- #1434 
- #1435
- #1436
- #1437
- #1438

#### Transports:

- Transports between factions will be changed so Synapol ones are slower but more resistant, and Yuruki ones are faster but less resistant;
- Bikes, Ramps and Money Transports occupy 2 slots on transport units. Other vehicles occupy 4;
- Yuruki Transports won't be able to CarryAll (ordering it to right click a vehicle to transport only it), since that's less convenient for players.

#### Cloaking:

- Cloaking units will always make a specific sound when activating or deactivating cloaking;
- All cloaking-capable units (Sniper Pod, Stealth Tank, Athmospheric Bomber) will decloak automatically when they have 25% HP or less, or when they attack;
- All cloaking units can cloak while moving or not attacking after a short time (varies per unit).

#### Other:

- Change Synapol's Drop Pods power so it always spawns 4 Mortars and 4 Rocketeers instead of being random amounts;
- Increase all units and buildings HP by 50% and increase Airstrike and Howitzer damages by 50%. This was necessary because previously it was so easy to clear unit masses and snipe specific buildings;
- Make Silo cost 3000 money and 250 power and Uplink cost 200 power so both the Nuke and the Uplink feel like a late-game tech hard to reach;
- Increase Tech Center money cost to 3000 and power cost to 250 and increase by 25% the cost for all tier 3 units except for Jetpackers and Jetfoilers since rushing tier 3 units was too strong and to encourage more plays with lower tier units;
- Increase range and vision of many AA capable units (Missile Tank, AA Tank, Patrol Boat, Light Boat) and buildings (both AA Turrets) since air was too dominant;
- Increase crushing evasion chance to 50% so pod masses are not easily countered by tank masses when they want to crush them;
- Make the AI also consider capturing Mining Towers with Technicians since that's what human players may usually do (this change requires the cost increase changes to make sense, for balancing);
- Make Rocketeers, Shockers, Assault Helicopters and Gunships have different armaments for anti-ground and anti-air (but having the same DPS) so their weapons don't damage ground when attacking air units and vice-versa;
- Define custom values for `IdealSeparation` and `RepulsionSpeed` for `^Plane` and both capital ships so it makes all player-controllable air units easier to micro.

</details>

<details><summary>Unit availability per type</summary>

#### Pods

| Synapol | Yuruki |
|--------|--------|
| Mortar | Sniper |
| Rocketeer | Shocker |
| Technician | Broker |
| Flamer | Bomber |
| Jetpacker | Jetfoiler | 

Since Machinegun pod was removed in favor of giving uniqueness for each faction, it was necessary to define tier 1 pods for each of them, unique enough to fit an anti-pod role.

Mortar pod can be massed more easily and has less range compared to Sniper but more raw firepower, including vs vehicles and buildings. Sniper pod can cloak and excels vs pods, but is bad vs vehicles and buildings. Sniper pod weapon also leaves a trail after firing so it's a bit easier to identify where the shots are coming from in early game, specially for a Synapol player, so pod fights are not that uneven.

Both Flamer and Bomber excel vs buildings. Flamer has continuous firing rate, consequently it needs to be exposed more but it's more resistant, and it can also be used with the army to damage other units. Bomber is a suicidal unit and moves faster but it's also a bit more fragile. Flamer prerequisite now is Radar Dome, so players are not obligated to create a different type of unit production facility to unlock them, which made no sense.

Jetpacker and Jetfoiler's idea is to be crowd control pods, used as support combat units. They shouldn't be power units. At the moment, Synapol's is good vs crowds of pods, and Yuruki's vs crowds of vehicles.

Broker Pod was also reworked and its range, cost, movement speed, and resource stealing amount were reduced, and pre-requisites have been changed. It can target Storages and Main Bases. To steal money, it needs to be deployed, becoming immobile. It has a green range circle indicating the resource stealing mechanic range, when deployed. Technician healing capabilities were also increased so he can be used like battlefield medics.

#### Vehicles

| Synapol | Yuruki |
|--------|--------|
| Missile Tank | Lightning Tank |
| Dual Artillery | Mobile AA |
| Ramp Buggy | Gatling Bike |
| Heavy APC | Light APC |
| Hacker Tank | Countermeasure Tank | 
| Railgun Tank | Stealth Tank | 

Some tanks function similarly between the factions, so it was necessary to do some rework on them.

The tier 1 tank for Synapol is going to be a combination of Missile Tank with their previous AA Tank. Since Missile Tank fires AG missiles, we thought it'd be a nice idea to let it also fire AA missiles. Since it now fits a flexible role, its cost was increased. Yuruki's basic tanks, instead, are going to be split between AG and AA. This lets a Yuruki player mass a specialized tank faster, but they need to be careful to don't mass units that are going to be useless later (for instance, massing AA tanks when the enemy stopped producing air units).

For Synapol, instead of having Artillery, it'll have the Dual Artillery since the sprite work has animations when firing and it gives a good distinction as an unit.

Since Yuruki is going to have two tier 1 tanks and Synapol one tier 1, and Yuruki's Sniper pod excels vs pods, it's reasonable to let Synapol have Dual Artillery to counter pod masses.

APCs had their base HP increased so they are not easily sniped by Rocketeers and Shockers.

For the tier 3 vehicles, both Railgun Tank and Stealth Tank fit perfectly the role for a power unit for each faction, but the Stealth Tank is more focused on stealth missions to fit Yuruki's gameplay design.

#### Aircraft

| Synapol | Yuruki |
|--------|--------|
| Observer | Scout Balloon |
| Assault Helicopter | Gun Ship |
| Turtle | Speeder |
| Transport Helicopter | Transport Dropship |
| Banshee | Athmospheric Bomber | 
| Mothership | Battleship | 

The major changes on this category are regarding Gun Ship, Speeder, Athmospheric Bomber, and Banshees.

For Gun Ship, Speeder and Athmospheric Bomber, they'll stop moving when attacking, behaving essentially like in Starcraft-like games because they were getting too exposed with the previous movement while attacking, making it not worth producing air units for most of the time.

Banshees and Athmospheric Bombers firepower were increased since they don't need ammo anymore. Also, Athmospheric Bomber can cloak while out of combat, fitting Yuruki's gameplay design. Banshee got a slight buff on resistance and DPS.

Since we now have new graphics for Yuruki's Gunship, the previous Plane has now `OpportunityFire` and `PersistentTargeting` so it can play differently. It's out of scope of this PR to properly balance the previous Plane, since it needs to be defined when it'll be used (probably in custom missions). Another PR balancing it can be done later.

Both Mothership and Battleship were defining the meta so they had their HP reduced.

#### Navy

| Synapol | Yuruki |
|--------|--------|
| Light Boat | Patrol Boat |
| Heavy Naval Transport | Light Naval Transport |
| Mercenary Boat | Submarine |
| Naval Minelayer | Naval Minelayer |
| Railgun Boat | Lightning Boat | 
| Drone Ship | Missile Submarine | 

For this category, it had a rebalance and a small reorganization regarding tier 2 boats and Railgun Boat and Lightning Boat. Now Synapol will have Mercenary Boat, which is a turret navy unit capable of also hitting ground, but with less anti-navy damage compared to Submarine.

Railgun Boat now can be deployed. While deployed, it becomes stationary and slightly increases its range and decreases its rate of fire. Lightning Boat lost its weapon, but now it increases the rate of fire of all friendly navy units nearby (except for Missile Submarine and Drone Ship since they are already strong).

</details> 

### Notes

- This PR needs more graphics for Jetfoiler, Tank and Naval Transports
- This PR needs graphic changes for Missile Submarine (color the flares as light blue at the center and blue at the border maybe)
- This PR needs graphic changes for Lightning Boat. Maybe merge all animated sequences into one?