### PR TITLE
Update Windows server image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
   windows:
     name: Windows (.NET 6.0)
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
       - name: Clone Repository


### PR DESCRIPTION
[Windows Server 2019 hosted runner image is closing down](https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/#windows-server-2019-is-closing-down)