### PR TITLE
Reduce Pods speed on Woods

### DIFF
--- a/mods/hv/rules/world.yaml
+++ b/mods/hv/rules/world.yaml
@@ -70,7 +70,7 @@
 			Black Sand: 90
 			Black Sand Ramp: 80
 			Stone: 100
-			Plant: 50
+			Plant: 25
 			Tech: 100
 			Rail: 80
 			Blocked: 90


### PR DESCRIPTION
So players have to command them to go in if they want pods to be inside forests.