### PR TITLE
Preliminary Balance on Railgunstrike

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -1606,7 +1606,7 @@ UPLINK:
 		SelectTargetSpeechNotification: SelectTarget
 		SelectTargetTextNotification: notification-select-target
 		IncomingSpeechNotification: OrbitalRailgunFired
-		AirburstAltitude: 40c0
+		AirburstAltitude: 400c0
 		CircleRanges: 3c0, 2c0, 1c0
 		CircleColor: 0000FF
 		CircleWidth: 2

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -1590,7 +1590,7 @@ UPLINK:
 		PauseOnCondition: lowpower
 		Icon: railgun
 		Cursor: railgun
-		ChargeInterval: 4500
+		ChargeInterval: 6750
 		Name: actor-uplink.railgun-name
 		Description: actor-uplink.railgun-description
 		DisplayTimerRelationships: Ally, Neutral, Enemy

--- a/mods/hv/weapons/energetic.yaml
+++ b/mods/hv/weapons/energetic.yaml
@@ -332,8 +332,8 @@ RailgunVisualStage2:
 	Projectile: GravityBomb
 		Image: railgun
 		Sequences: idle
-		Velocity: 0,0,-60 # needs to be synced with RailgunStrike
-		Acceleration: 0,0,-45 # needs to be synced with RailgunStrike
+		Velocity: 0,0,-30 # needs to be synced with RailgunStrike
+		Acceleration: 0,0,-23 # needs to be synced with RailgunStrike
 	Warhead@Effect: CreateEffect
 		Explosions: railgun
 		ImpactSounds: explosion06.ogg
@@ -341,8 +341,8 @@ RailgunVisualStage2:
 
 RailgunStrike:
 	Projectile: GravityBomb
-		Velocity: 0,0,-60 # needs to be synced with RailgunVisualStage2
-		Acceleration: 0,0,-45 # needs to be synced with RailgunVisualStage2
+		Velocity: 0,0,-30 # needs to be synced with RailgunVisualStage2
+		Acceleration: 0,0,-23 # needs to be synced with RailgunVisualStage2
 	ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
 	Report: raygun_newlocknew.ogg
 	Warhead@DamageImpact: SpreadDamage


### PR DESCRIPTION
Changes to attempt to make it more balanced:

- Increase Railgunstrike 'ChargeInterval' so it recharges half Synapol's Nuke time
- Reduce Railgunstrike projectile Velocity and Acceleration by half and Increase Railgunstrike 'AirburstAltitude' so it takes around 4 seconds to fall to the ground, giving time for the opponent to react