### PR TITLE
Standardize support power countdowns to begin only after the building is completed from beaming up

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -378,6 +378,7 @@ RADAR:
 		RequiresCondition: !powerdown
 	AirstrikePower:
 		PauseOnCondition: lowpower || disabled
+		RequiresCondition: !build-incomplete && !beam-incomplete
 		Icon: airstrike
 		Cursor: airstrike
 		ChargeInterval: 3750
@@ -404,9 +405,10 @@ RADAR2:
 		Prerequisites: storage, ~structures.sc
 	-AirstrikePower:
 	DropPodsPower:
-		Cursor: droppod
-		PauseOnCondition: disabled || disabled
+		PauseOnCondition: disabled
+		RequiresCondition: !build-incomplete && !beam-incomplete
 		Icon: droppods
+		Cursor: droppod
 		Name: actor-radar2.droppodspower-name
 		Description: actor-radar2.droppodspower-description
 		DisplayRadarPing: true
@@ -1411,6 +1413,7 @@ HOWITZER:
 		LocalOffset: 1500,50,1400
 	AttackOrderPower:
 		PauseOnCondition: disabled
+		RequiresCondition: !build-incomplete && !beam-incomplete
 		AttackingCondition: attacking
 		Cursor: attack
 		BlockedCursor: howitzer-blocked
@@ -1557,6 +1560,7 @@ SILO:
 		Range: 4c0
 	NukePower:
 		PauseOnCondition: disabled
+		RequiresCondition: !build-incomplete && !beam-incomplete
 		Cursor: nuke
 		Icon: nuke
 		ChargeInterval: 13500
@@ -1647,6 +1651,7 @@ UPLINK:
 	DetonateWeaponPower:
 		OrderName: Blastem
 		PauseOnCondition: lowpower
+		RequiresCondition: !build-incomplete && !beam-incomplete
 		Icon: railgun
 		Cursor: railgun
 		ChargeInterval: 6750
@@ -1797,6 +1802,7 @@ TELEVATOR:
 		RequiredForShortGame: false
 	TeleportPower:
 		PauseOnCondition: disabled
+		RequiresCondition: !build-incomplete && !beam-incomplete
 		Dimensions: 3, 3
 		Footprint: xxx xxx xxx
 		DisplayRadarPing: True


### PR DESCRIPTION
Fixes #1340 