### PR TITLE
Make Miner deploy on ore rallypoints

### DIFF
--- a/OpenRA.Mods.HV/Activities/DeployMiner.cs
+++ b/OpenRA.Mods.HV/Activities/DeployMiner.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.HV.Activities
 					self.World.IssueOrder(order);
 
 				QueueChild(movement.MoveTo(location.Value));
-				self.Trait<Transforms>().DeployTransform(true);
+				QueueChild(self.Trait<Transforms>().GetTransformActivity());
 			}
 
 			return true;

--- a/OpenRA.Mods.HV/Activities/Extensions.cs
+++ b/OpenRA.Mods.HV/Activities/Extensions.cs
@@ -1,0 +1,32 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2019-2025 The OpenHV Developers (see CREDITS)
+ * This file is part of OpenHV, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Activities;
+
+namespace OpenRA.Mods.HV.Activities
+{
+	public static class Extensions
+	{
+		public static void InsertActivityInQueue(Actor actor, Activity insertAfterThisActivity, Activity activityToInsert)
+		{
+			if (insertAfterThisActivity == null)
+				actor.QueueActivity(activityToInsert);
+			if (insertAfterThisActivity.NextActivity == null)
+				insertAfterThisActivity.Queue(activityToInsert);
+
+			var activityToReplace = insertAfterThisActivity.NextActivity;
+			var followingActivities = activityToReplace.NextActivity;
+			activityToReplace.Cancel(actor);
+			insertAfterThisActivity.Queue(activityToInsert);
+			insertAfterThisActivity.Queue(followingActivities);
+		}
+	}
+}

--- a/OpenRA.Mods.HV/OpenRA.Mods.HV.csproj.user
+++ b/OpenRA.Mods.HV/OpenRA.Mods.HV.csproj.user
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ActiveDebugProfile>OpenHV</ActiveDebugProfile>
+  </PropertyGroup>
+</Project>

--- a/OpenRA.Mods.HV/Properties/launchSettings.json
+++ b/OpenRA.Mods.HV/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "OpenRA.Mods.HV": {
+      "commandName": "Project"
+    },
+    "OpenHV": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Users\\IvanP\\Downloads\\OpenHV-BugFixes\\engine\\bin\\OpenRA.exe",
+      "commandLineArgs": "Game.Mod=hv Engine.EngineDir=\"..\" Engine.ModSearchPaths=\"../../mods\"",
+      "workingDirectory": "C:\\Users\\IvanP\\Downloads\\OpenHV-BugFixes\\engine\\bin\\"
+    }
+  }
+}

--- a/OpenRA.Mods.HV/UtilityCommands/Extensions.cs
+++ b/OpenRA.Mods.HV/UtilityCommands/Extensions.cs
@@ -11,6 +11,7 @@
 
 using System.Data;
 using System.Text;
+using OpenRA.Activities;
 
 namespace OpenRA.Mods.HV.UtilityCommands
 {
@@ -49,6 +50,20 @@ namespace OpenRA.Mods.HV.UtilityCommands
 			result.AppendLine();
 
 			return result.ToString();
+		}
+
+		public static void InsertActivityInQueue(Actor actor, Activity insertAfterThisActivity, Activity activityToInsert)
+		{
+			if (insertAfterThisActivity == null)
+				actor.QueueActivity(activityToInsert);
+			if (insertAfterThisActivity.NextActivity == null)
+				insertAfterThisActivity.Queue(activityToInsert);
+
+			var activityToReplace = insertAfterThisActivity.NextActivity;
+			var followingActivities = activityToReplace.NextActivity;
+			activityToReplace.Cancel(actor);
+			insertAfterThisActivity.Queue(activityToInsert);
+			insertAfterThisActivity.Queue(followingActivities);
 		}
 	}
 }

--- a/OpenRA.Mods.HV/UtilityCommands/Extensions.cs
+++ b/OpenRA.Mods.HV/UtilityCommands/Extensions.cs
@@ -11,7 +11,6 @@
 
 using System.Data;
 using System.Text;
-using OpenRA.Activities;
 
 namespace OpenRA.Mods.HV.UtilityCommands
 {
@@ -50,20 +49,6 @@ namespace OpenRA.Mods.HV.UtilityCommands
 			result.AppendLine();
 
 			return result.ToString();
-		}
-
-		public static void InsertActivityInQueue(Actor actor, Activity insertAfterThisActivity, Activity activityToInsert)
-		{
-			if (insertAfterThisActivity == null)
-				actor.QueueActivity(activityToInsert);
-			if (insertAfterThisActivity.NextActivity == null)
-				insertAfterThisActivity.Queue(activityToInsert);
-
-			var activityToReplace = insertAfterThisActivity.NextActivity;
-			var followingActivities = activityToReplace.NextActivity;
-			activityToReplace.Cancel(actor);
-			insertAfterThisActivity.Queue(activityToInsert);
-			insertAfterThisActivity.Queue(followingActivities);
 		}
 	}
 }


### PR DESCRIPTION
Allows miners to AttackMove to rallypoint cells without ore and deploy on rallypoint cells with ore. 
It requires creationRallypoint from Mobile.cs to be made public (Although this field can also be obtained through reflection if necessary).
A change on the LeaveProductionActivity class (in Mobile.cs) is also necessary, as without that change the miner will go through all the AttackMove rallypoints before going back to the deploy rallypoints.

These required changes to the engine are documented in OpenRA/OpenRA#21986