### PR TITLE
Change Projectile Speed for Anti-Tank Turrets and Cannon-based Units

### DIFF
--- a/mods/hv/weapons/ballistics.yaml
+++ b/mods/hv/weapons/ballistics.yaml
@@ -7,7 +7,7 @@
 	ReloadDelay: 70
 	Range: 6c0
 	Projectile: Bullet
-		Speed: 682
+		Speed: 1750
 		Image: bullet1
 		Shadow: true
 	Warhead@Smudge: LeaveSmudge


### PR DESCRIPTION
So they should always hit their targets with full damage even when they are moving fast.