### PR TITLE
Standardize explosion effects

### DIFF
--- a/mods/hv/rules/aircraft.yaml
+++ b/mods/hv/rules/aircraft.yaml
@@ -593,6 +593,10 @@ CHOPPER:
 	-GrantRandomCondition@SpawnPilot:
 	WithAircraftLandingEffect:
 		Image: landing
+	FireWarheadsOnDeath:
+		Weapon: UnitExplodeLarge
+		EmptyWeapon: UnitExplodeLarge
+		RequiresCondition: !airborne
 
 CHOPPER.Husk:
 	Inherits: ^PlaneHusk
@@ -602,7 +606,7 @@ CHOPPER.Husk:
 		TurnSpeed: 24
 		Speed: 86
 	FallsToEarth:
-		Explosion: UnitExplodeLarge
+		Explosion: UnitExplodeLargeDamaging
 		Velocity: 43
 		MaximumSpinSpeed: 64
 	LeavesTrails:
@@ -611,6 +615,23 @@ CHOPPER.Husk:
 		Image: smoke
 		SpawnAtLastPosition: false
 		Type: CenterPosition
+	LeavesTrails@ExplosionMain:
+		Offsets: 250,0,0
+		MovingInterval: 5
+		Image: explosion
+		Sequences: medium_3
+		SpawnAtLastPosition: false
+		Type: CenterPosition
+	LeavesTrails@ExplosionSides:
+		Offsets: 550,0,0, 250,300,0, -50,0,0, 250,-300,0
+		MovingInterval: 6
+		Image: explosion
+		Sequences: small_2
+		SpawnAtLastPosition: false
+		Type: CenterPosition
+	AmbientSound:
+		SoundFiles: flame_explode_magnuswaker.ogg
+		Interval: 8
 	RevealsShroud:
 		Range: 4c0
 		MinRange: 2c0
@@ -742,6 +763,10 @@ DROPSHIP:
 	-FireWarheadsOnDeath@SpawnPilot:
 	WithAircraftLandingEffect:
 		Image: landing
+	FireWarheadsOnDeath:
+		Weapon: UnitExplodeLarge
+		EmptyWeapon: UnitExplodeLarge
+		RequiresCondition: !airborne
 
 DROPSHIP.Husk:
 	Inherits: ^PlaneHusk
@@ -751,14 +776,31 @@ DROPSHIP.Husk:
 		TurnSpeed: 24
 		Speed: 86
 	FallsToEarth:
-		Explosion: UnitExplodeLarge
+		Explosion: UnitExplodeLargeDamaging
 		Velocity: 43
 	LeavesTrails:
-		Offsets: -853,0,171
+		Offsets: -250,0,171
 		MovingInterval: 2
 		Image: smoke
 		SpawnAtLastPosition: false
 		Type: CenterPosition
+	LeavesTrails@ExplosionMain:
+		Offsets: 250,0,0
+		MovingInterval: 5
+		Image: explosion
+		Sequences: medium_3
+		SpawnAtLastPosition: false
+		Type: CenterPosition
+	LeavesTrails@ExplosionSides:
+		Offsets: 550,0,0, 250,300,0, -50,0,0, 250,-300,0
+		MovingInterval: 6
+		Image: explosion
+		Sequences: small_2
+		SpawnAtLastPosition: false
+		Type: CenterPosition
+	AmbientSound:
+		SoundFiles: flame_explode_magnuswaker.ogg
+		Interval: 8
 	RevealsShroud:
 		Range: 4c0
 		MinRange: 2c0
@@ -941,6 +983,9 @@ BOMBER:
 		FacingTolerance: 512
 	Armament:
 		Weapon: Bomb
+	FireWarheadsOnDeath:
+		Weapon: UnitExplodeMedium
+		EmptyWeapon: UnitExplodeMedium
 
 CARGOSHIP:
 	Inherits: ^CargoPlane
@@ -1096,15 +1141,29 @@ MOTHERSHIP.Husk:
 		Image: smoke
 		SpawnAtLastPosition: false
 		Type: CenterPosition
-	LeavesTrails@Explosion:
-		Offsets: 0,0,171
-		MovingInterval: 10
+	LeavesTrails@ExplosionMain:
+		Offsets: 500,0,0
+		MovingInterval: 5
 		Image: explosion
 		Sequences: medium_3
 		SpawnAtLastPosition: false
 		Type: CenterPosition
+	LeavesTrails@ExplosionSides:
+		Offsets: 1100,0,0, 500,600,0, -100,0,0, 500,-600,0
+		MovingInterval: 6
+		Image: explosion
+		Sequences: medium_3
+		SpawnAtLastPosition: false
+		Type: CenterPosition
+	LeavesTrails@ExplosionDiagonals:
+		Offsets: 800,300,0, 800,-300,0, 200,300,0, 200,-300,0
+		MovingInterval: 4
+		Image: explosion
+		Sequences: small_2
+		SpawnAtLastPosition: false
+		Type: CenterPosition
 	AmbientSound:
-		SoundFiles: explosion02.ogg, explosion03.ogg
+		SoundFiles: flame_explode_magnuswaker.ogg
 		Interval: 5
 	RevealsShroud:
 		Range: 4c0
@@ -1239,15 +1298,29 @@ BATTLESHIP.Husk:
 		Image: smoke
 		SpawnAtLastPosition: false
 		Type: CenterPosition
-	LeavesTrails@Explosion:
-		Offsets: 0,0,171
-		MovingInterval: 10
+	LeavesTrails@ExplosionMain:
+		Offsets: 500,0,0
+		MovingInterval: 5
 		Image: explosion
 		Sequences: medium_3
 		SpawnAtLastPosition: false
 		Type: CenterPosition
+	LeavesTrails@ExplosionSides:
+		Offsets: 1100,0,0, 500,600,0, -100,0,0, 500,-600,0
+		MovingInterval: 6
+		Image: explosion
+		Sequences: medium_3
+		SpawnAtLastPosition: false
+		Type: CenterPosition
+	LeavesTrails@ExplosionDiagonals:
+		Offsets: 800,300,0, 800,-300,0, 200,300,0, 200,-300,0
+		MovingInterval: 4
+		Image: explosion
+		Sequences: small_2
+		SpawnAtLastPosition: false
+		Type: CenterPosition
 	AmbientSound:
-		SoundFiles: explosion02.ogg, explosion03.ogg
+		SoundFiles: flame_explode_magnuswaker.ogg
 		Interval: 5
 	RevealsShroud:
 		Range: 4c0

--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -2045,9 +2045,6 @@ BARRIER:
 		Pieces: 0, 1
 		Range: 1c512, 3c0
 	Demolishable:
-	FireWarheadsOnDeath:
-		Weapon: UnitExplodeLarge
-		EmptyWeapon: UnitExplodeLarge
 	MapEditorData:
 		Categories: Wall
 	RevealsShroud:

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -333,8 +333,6 @@
 ^PlaneHusk:
 	Inherits@Husk: ^Husk
 	Inherits@Sprite: ^SpriteActor
-	Targetable:
-		TargetTypes: Air, Husk, NoAutoTarget
 	WithShadow:
 		Offset: 43, 128, 0
 		ZOffset: -129

--- a/mods/hv/rules/defaults.yaml
+++ b/mods/hv/rules/defaults.yaml
@@ -163,8 +163,8 @@
 	Voiced:
 		VoiceSet: GenericVoice3
 	FireWarheadsOnDeath:
-		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
+		Weapon: UnitExplodeMedium
+		EmptyWeapon: UnitExplodeMedium
 	SpawnScrapOnDeath:
 		Actors: scrap1, scrap2, scrap3, scrap4, scrap5
 		TerrainTypes: Clear, Crater, Road, Grass, Grass Pit, Mountain, Snow, Red Snow, Sand, Black Sand, Stone, Tech
@@ -228,6 +228,9 @@
 		Condition: concealed
 	Cloak@Foliage:
 		RequiresCondition: concealed
+	FireWarheadsOnDeath:
+		Weapon: UnitExplodeSmall
+		EmptyWeapon: UnitExplodeSmall
 
 ^Scrap:
 	Interactable:
@@ -323,6 +326,9 @@
 		Weapon: PilotSpawn
 		EmptyWeapon: PilotSpawn
 		RequiresCondition: spawn-pilot && !dont-spawn-pilot
+	FireWarheadsOnDeath:
+		Weapon: UnitExplodeMedium
+		EmptyWeapon: UnitExplodeMedium
 
 ^PlaneHusk:
 	Inherits@Husk: ^Husk
@@ -356,6 +362,9 @@
 	Aircraft:
 		IdleBehavior: None
 		Repulsable: False
+	FireWarheadsOnDeath:
+		Weapon: UnitExplodeSmall
+		EmptyWeapon: UnitExplodeSmall
 
 ^CargoPlane:
 	Inherits@Exists: ^ExistsInWorld
@@ -963,8 +972,8 @@
 	ProximityCaptor:
 		Types: Ship
 	FireWarheadsOnDeath:
-		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
+		Weapon: UnitExplodeMedium
+		EmptyWeapon: UnitExplodeMedium
 	Guard:
 		Voice: Guard
 	Guardable:

--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -189,6 +189,9 @@ APC:
 		Image: energyball
 		Sequence: teleport-large
 	-Passenger:
+	FireWarheadsOnDeath:
+		Weapon: UnitExplodeLarge
+		EmptyWeapon: UnitExplodeLarge
 
 ARTILLERY:
 	Inherits: ^TrackedVehicle
@@ -238,9 +241,8 @@ ARTILLERY:
 		FacingTolerance: 0
 	WithMuzzleOverlay:
 	FireWarheadsOnDeath:
-		Weapon: ArtilleryExplode
-		EmptyWeapon: UnitExplodeSmall
-		LoadedChance: 75
+		Weapon: UnitExplodeMedium
+		EmptyWeapon: UnitExplodeMedium
 
 RADARTANK:
 	Inherits: ^TrackedVehicle

--- a/mods/hv/sequences/weapons.yaml
+++ b/mods/hv/sequences/weapons.yaml
@@ -8,8 +8,10 @@ explosion:
 		Filename: bits/expsmall.png
 	small_2:
 		Filename: bits/expsmall2.png
+		Scale: 1.1
 	medium:
 		Filename: bits/explosn.png
+		Scale: 1.1
 	medium_2:
 		Filename: bits/explosn2.png
 	medium_3:

--- a/mods/hv/weapons/explosions.yaml
+++ b/mods/hv/weapons/explosions.yaml
@@ -8,44 +8,49 @@ BuildingExplode:
 ^Explosion:
 	ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
 	Warhead@Damage: SpreadDamage
-		DamageTypes: Fire
 		Spread: 426
-		Damage: 5000
-		Versus:
-			None: 90
-			Steel: 75
+		Damage: 0
 	Warhead@Incendiary: TreeDamage
 		Spread: 426
-		Damage: 5000
+		Damage: 0
 	Warhead@Effect: CreateEffect
 		Explosions: small_2
 		ValidTargets: Ground, Air, Water, Lava, Swamp
 		ImpactSounds: explosion02.ogg, explosion03.ogg
 
-ArtilleryExplode:
-	Inherits: ^Explosion
-	Warhead@Damage: SpreadDamage
-		Damage: 15000
-	Warhead@Effect: CreateEffect
-		Explosions: medium
-		ImpactSounds: explosion04.ogg, explosion05.ogg
-
 UnitExplodeSmall:
 	Inherits: ^Explosion
-	Warhead@Damage: SpreadDamage
-		Damage: 4000
+	Warhead@Effect: CreateEffect
+		Explosions: small_2
+
+UnitExplodeMedium:
+	Inherits: ^Explosion
+	Warhead@Effect: CreateEffect
+		Explosions: medium_2
 
 UnitExplodeLarge:
 	Inherits: ^Explosion
 	Warhead@Effect: CreateEffect
 		Explosions: large
+
+UnitExplodeLargeDamaging:
+	Inherits: UnitExplodeLarge
+	Warhead@Effect: CreateEffect
+		Explosions: large
 	Warhead@Damage: SpreadDamage
 		Damage: 8000
+	Warhead@Incendiary: TreeDamage
+		Damage: 8000
+
+UnitExplodeHuge:
+	Inherits: ^Explosion
+	Warhead@Effect: CreateEffect
+		Explosions: large_3
 
 PropExplode:
 	Inherits: ^Explosion
 	Warhead@Damage: SpreadDamage
-		Damage: 4000
+		Damage: 0
 	Warhead@Effect: CreateEffect
 		Explosions: medium
 
@@ -128,7 +133,7 @@ BlasterExplosion:
 			Concrete: 50
 	Warhead@Effect: CreateEffect
 		Image: explosion
-		Explosions: medium, medium_2
+		Explosions: medium
 		ImpactSounds: explosion02.ogg, explosion03.ogg
 		ValidTargets: Ground, Water, Ship, Air, Structure
 

--- a/mods/hv/weapons/explosions.yaml
+++ b/mods/hv/weapons/explosions.yaml
@@ -97,48 +97,6 @@ DropPodExplode:
 		ValidTargets: Ground, Air, Water, Lava, Swamp
 		ImpactSounds: explosion02.ogg, explosion03.ogg
 
-MortarExplode:
-	ValidTargets: Ground, Air, Water, Lava, Swamp
-	Warhead@Damage: SpreadDamage
-		DamageTypes: Fire
-		Spread: 512
-		Damage: 7500
-		Versus:
-			None: 100
-			Steel: 50
-			Light: 25
-			Heavy: 25
-			Wood: 50
-	Warhead@Incendiary: TreeDamage
-		Spread: 512
-		Damage: 7500
-		Percentage: 50
-	Warhead@Effect: CreateEffect
-		Explosions: small_2
-		ValidTargets: Ground, Air, Water, Lava, Swamp
-		ImpactSounds: explosion01.ogg
-
-FlameExplode:
-	ValidTargets: Ground, Air, Water, Lava, Swamp
-	Warhead@Damage: SpreadDamage
-		DamageTypes: Fire
-		Spread: 512
-		Damage: 7500
-		Versus:
-			None: 125
-			Steel: 50
-			Light: 5
-			Heavy: 5
-			Wood: 100
-	Warhead@Incendiary: TreeDamage
-		Spread: 512
-		Damage: 7500
-		Percentage: 50
-	Warhead@Effect: CreateEffect
-		Explosions: small_2
-		ValidTargets: Ground, Air, Water, Lava, Swamp
-		ImpactSounds: flame_explode_magnuswaker.ogg
-
 ExplosiveCharge:
 	ValidTargets: Ground, Structure
 	Range: 2c0

--- a/mods/hv/weapons/explosions.yaml
+++ b/mods/hv/weapons/explosions.yaml
@@ -9,10 +9,8 @@ BuildingExplode:
 	ValidTargets: Ground, Water, Air, Tree, Lava, Swamp
 	Warhead@Damage: SpreadDamage
 		Spread: 426
-		Damage: 0
 	Warhead@Incendiary: TreeDamage
 		Spread: 426
-		Damage: 0
 	Warhead@Effect: CreateEffect
 		Explosions: small_2
 		ValidTargets: Ground, Air, Water, Lava, Swamp
@@ -49,8 +47,6 @@ UnitExplodeHuge:
 
 PropExplode:
 	Inherits: ^Explosion
-	Warhead@Damage: SpreadDamage
-		Damage: 0
 	Warhead@Effect: CreateEffect
 		Explosions: medium
 


### PR DESCRIPTION
- Removes unused explosion definitions
- Unit death explosions are bigger
- Prevent unit death explosions from dealing damage except for ones that explode upon ground impact, from minelayers or from Bomb Pods
- Improve husks explosion effects of capital ships and air transports when they are falling from the sky
- Prevent husks from being destroyed so they don't disappear mid-air when eliminated