### PR TITLE
Increase projectile speeds for 'BuggyChainGun' and 'BoatMachineGunGround'

### DIFF
--- a/mods/hv/weapons/firearms.yaml
+++ b/mods/hv/weapons/firearms.yaml
@@ -99,7 +99,7 @@ BuggyChainGun:
 	Burst: 4
 	Projectile: Bullet
 		Inaccuracy: 0c256
-		Speed: 1750
+		Speed: 3500
 		ContrailLength: 3
 		ContrailStartWidth: 0c32
 		ContrailStartColor: F4AC00
@@ -236,7 +236,7 @@ BoatMachineGunGround:
 	Burst: 4
 	Projectile: Bullet
 		Inaccuracy: 0c256
-		Speed: 1000
+		Speed: 3500
 		ContrailLength: 3
 		ContrailStartWidth: 0c32
 		ContrailStartColor: F4AC00


### PR DESCRIPTION
To 3500 so both weapons (and any weapon based on them) can hit fast moving targets with full damage.