### PR TITLE
Improve Footprint for Ore Smelters / Purifiers and Outposts

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -264,7 +264,7 @@ OUTPOST:
 	Health:
 		HP: 50000
 	Building:
-		Footprint: x x
+		Footprint: + x
 		Dimensions: 1,2
 	HitShape:
 		Type: Circle
@@ -1135,7 +1135,7 @@ ORESMELT:
 	Power:
 		Amount: -80
 	Building:
-		Footprint: x x
+		Footprint: + x
 		Dimensions: 1,2
 	RevealsShroud:
 		Range: 4c0


### PR DESCRIPTION
Complementary to #1401. We thought it'll be better to use `+` so units could pass behind the top cell.