### PR TITLE
Fix: Repair tank auto-targets allies only

### DIFF
--- a/mods/hv/rules/vehicles.yaml
+++ b/mods/hv/rules/vehicles.yaml
@@ -367,6 +367,7 @@ REPAIRTANK:
 		InitialStance: AttackAnything
 	AutoTargetPriority@Default:
 		ValidTargets: DamagedVehicle
+		TargetRelationships: Ally
 
 MINELAYER:
 	Inherits: ^TrackedVehicle


### PR DESCRIPTION
The REPAIRTANK was incorrectly configured to auto-target any damaged vehicle, including enemies. This change restricts the auto-targeting to allied units only by adding `TargetRelationships: Ally` to the `AutoTargetPriority@Default` trait.