### PR TITLE
Change Silo and Uplink costs

### DIFF
--- a/mods/hv/rules/buildings.yaml
+++ b/mods/hv/rules/buildings.yaml
@@ -1541,7 +1541,7 @@ SILO:
 	Selectable:
 		Bounds: 2048, 3072, 0, -1024
 	Valued:
-		Cost: 2500
+		Cost: 3000
 	Tooltip:
 		Name: actor-silo.name
 	Encyclopedia:
@@ -1600,7 +1600,7 @@ SILO:
 		CircleWidth: 2
 	SupportPowerChargeBar:
 	Power:
-		Amount: -150
+		Amount: -240
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	WithIdleOverlay@Lights:
@@ -1653,7 +1653,7 @@ UPLINK:
 		Range: 4c0
 	SupportPowerChargeBar:
 	Power:
-		Amount: -150
+		Amount: -240
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	WithIdleOverlay@Lights:


### PR DESCRIPTION
 So both the Nuke and the Uplink feel like a late-game tech hard to reach

**Silo changes:**

- 3000 money
- 240 power


**Uplink changes:**

- 240 power